### PR TITLE
Rename rapids_metadata variable to all_metadata

### DIFF
--- a/src/rapids_metadata/__init__.py
+++ b/src/rapids_metadata/__init__.py
@@ -20,12 +20,12 @@ from .metadata import (
 )
 
 
-__all__ = ["rapids_metadata"]
+__all__ = ["all_metadata"]
 
 
-rapids_metadata: RAPIDSMetadata = RAPIDSMetadata()
+all_metadata: RAPIDSMetadata = RAPIDSMetadata()
 
-rapids_metadata.versions["24.08"] = RAPIDSVersion(
+all_metadata.versions["24.08"] = RAPIDSVersion(
     repositories={
         "_nvidia": RAPIDSRepository(
             packages={

--- a/src/rapids_metadata/json.py
+++ b/src/rapids_metadata/json.py
@@ -19,7 +19,7 @@ import os
 import sys
 from typing import Any, Union
 
-from . import rapids_metadata
+from . import all_metadata
 from .metadata import (
     RAPIDSMetadata,
     RAPIDSPackage,
@@ -47,11 +47,11 @@ def main():
 
     parsed = parser.parse_args()
     metadata = (
-        rapids_metadata
+        all_metadata
         if parsed.all_versions
         else RAPIDSMetadata(
             versions={
-                get_rapids_version(os.getcwd()): rapids_metadata.get_current_version(
+                get_rapids_version(os.getcwd()): all_metadata.get_current_version(
                     os.getcwd()
                 )
             }

--- a/tests/metadata/test_json.py
+++ b/tests/metadata/test_json.py
@@ -260,7 +260,7 @@ def test_main(capsys, tmp_path, version, args, expected_json):
         with open(os.path.join(tmp_path, "VERSION"), "w") as f:
             f.write(f"{version}\n")
     with set_cwd(tmp_path), patch("sys.argv", ["rapids-metadata-json", *args]), patch(
-        "rapids_metadata.json.rapids_metadata", mock_metadata
+        "rapids_metadata.json.all_metadata", mock_metadata
     ):
         rapids_json.main()
     captured = capsys.readouterr()


### PR DESCRIPTION
Having the variable named the same as its parent module creates confusion. Rename it to make the meaning clearer.