### PR TITLE
Rename has_alpha_spec to publishes_prereleases

### DIFF
--- a/src/rapids_metadata/metadata.py
+++ b/src/rapids_metadata/metadata.py
@@ -28,7 +28,7 @@ __all__ = [
 
 @dataclass
 class RAPIDSPackage:
-    has_nightly_builds: bool = field(default=True)
+    publishes_prereleases: bool = field(default=True)
     has_cuda_suffix: bool = field(default=True)
 
 
@@ -50,12 +50,12 @@ class RAPIDSVersion:
         }
 
     @property
-    def nightly_build_packages(self) -> set[str]:
+    def prerelease_packages(self) -> set[str]:
         return {
             package
             for repository_data in self.repositories.values()
             for package, package_data in repository_data.packages.items()
-            if package_data.has_nightly_builds
+            if package_data.publishes_prereleases
         }
 
     @property

--- a/src/rapids_metadata/metadata.py
+++ b/src/rapids_metadata/metadata.py
@@ -28,7 +28,7 @@ __all__ = [
 
 @dataclass
 class RAPIDSPackage:
-    has_alpha_spec: bool = field(default=True)
+    has_nightly_builds: bool = field(default=True)
     has_cuda_suffix: bool = field(default=True)
 
 
@@ -50,12 +50,12 @@ class RAPIDSVersion:
         }
 
     @property
-    def alpha_spec_packages(self) -> set[str]:
+    def nightly_build_packages(self) -> set[str]:
         return {
             package
             for repository_data in self.repositories.values()
             for package, package_data in repository_data.packages.items()
-            if package_data.has_alpha_spec
+            if package_data.has_nightly_builds
         }
 
     @property

--- a/tests/metadata/test_version.py
+++ b/tests/metadata/test_version.py
@@ -23,20 +23,20 @@ def metadata():
             "repo1": md.RAPIDSRepository(
                 packages={
                     "package1": md.RAPIDSPackage(
-                        has_nightly_builds=True, has_cuda_suffix=True
+                        publishes_prereleases=True, has_cuda_suffix=True
                     ),
                     "package2": md.RAPIDSPackage(
-                        has_nightly_builds=True, has_cuda_suffix=False
+                        publishes_prereleases=True, has_cuda_suffix=False
                     ),
                 }
             ),
             "repo2": md.RAPIDSRepository(
                 packages={
                     "package3": md.RAPIDSPackage(
-                        has_nightly_builds=False, has_cuda_suffix=True
+                        publishes_prereleases=False, has_cuda_suffix=True
                     ),
                     "package4": md.RAPIDSPackage(
-                        has_nightly_builds=False, has_cuda_suffix=False
+                        publishes_prereleases=False, has_cuda_suffix=False
                     ),
                 }
             ),
@@ -48,8 +48,8 @@ def test_all_packages(metadata):
     assert metadata.all_packages == {"package1", "package2", "package3", "package4"}
 
 
-def test_nightly_build_packages(metadata):
-    assert metadata.nightly_build_packages == {"package1", "package2"}
+def test_prerelease_packages(metadata):
+    assert metadata.prerelease_packages == {"package1", "package2"}
 
 
 def test_cuda_suffixed_packages(metadata):

--- a/tests/metadata/test_version.py
+++ b/tests/metadata/test_version.py
@@ -23,20 +23,20 @@ def metadata():
             "repo1": md.RAPIDSRepository(
                 packages={
                     "package1": md.RAPIDSPackage(
-                        has_alpha_spec=True, has_cuda_suffix=True
+                        has_nightly_builds=True, has_cuda_suffix=True
                     ),
                     "package2": md.RAPIDSPackage(
-                        has_alpha_spec=True, has_cuda_suffix=False
+                        has_nightly_builds=True, has_cuda_suffix=False
                     ),
                 }
             ),
             "repo2": md.RAPIDSRepository(
                 packages={
                     "package3": md.RAPIDSPackage(
-                        has_alpha_spec=False, has_cuda_suffix=True
+                        has_nightly_builds=False, has_cuda_suffix=True
                     ),
                     "package4": md.RAPIDSPackage(
-                        has_alpha_spec=False, has_cuda_suffix=False
+                        has_nightly_builds=False, has_cuda_suffix=False
                     ),
                 }
             ),
@@ -48,8 +48,8 @@ def test_all_packages(metadata):
     assert metadata.all_packages == {"package1", "package2", "package3", "package4"}
 
 
-def test_alpha_spec_packages(metadata):
-    assert metadata.alpha_spec_packages == {"package1", "package2"}
+def test_nightly_build_packages(metadata):
+    assert metadata.nightly_build_packages == {"package1", "package2"}
 
 
 def test_cuda_suffixed_packages(metadata):

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -41,24 +41,24 @@ def set_cwd(cwd: os.PathLike) -> Generator:
 @pytest.mark.parametrize(
     ["unencoded", "encoded"],
     [
-        (RAPIDSPackage(), {"has_nightly_builds": True, "has_cuda_suffix": True}),
+        (RAPIDSPackage(), {"publishes_prereleases": True, "has_cuda_suffix": True}),
         (
             RAPIDSRepository(
                 packages={
                     "package1": RAPIDSPackage(),
                     "package2": RAPIDSPackage(
-                        has_nightly_builds=False, has_cuda_suffix=False
+                        publishes_prereleases=False, has_cuda_suffix=False
                     ),
                 }
             ),
             {
                 "packages": {
                     "package1": {
-                        "has_nightly_builds": True,
+                        "publishes_prereleases": True,
                         "has_cuda_suffix": True,
                     },
                     "package2": {
-                        "has_nightly_builds": False,
+                        "publishes_prereleases": False,
                         "has_cuda_suffix": False,
                     },
                 },
@@ -88,7 +88,7 @@ def set_cwd(cwd: os.PathLike) -> Generator:
                     "repo2": {
                         "packages": {
                             "package": {
-                                "has_nightly_builds": True,
+                                "publishes_prereleases": True,
                                 "has_cuda_suffix": True,
                             },
                         },
@@ -96,7 +96,7 @@ def set_cwd(cwd: os.PathLike) -> Generator:
                     "_nvidia": {
                         "packages": {
                             "proprietary-package": {
-                                "has_nightly_builds": True,
+                                "publishes_prereleases": True,
                                 "has_cuda_suffix": True,
                             },
                         },
@@ -150,7 +150,7 @@ def test_metadata_encoder(unencoded, encoded):
                                 "packages": {
                                     "package": {
                                         "has_cuda_suffix": True,
-                                        "has_nightly_builds": True,
+                                        "publishes_prereleases": True,
                                     },
                                 },
                             },
@@ -170,7 +170,7 @@ def test_metadata_encoder(unencoded, encoded):
                                 "packages": {
                                     "package": {
                                         "has_cuda_suffix": True,
-                                        "has_nightly_builds": True,
+                                        "publishes_prereleases": True,
                                     },
                                 },
                             },
@@ -190,7 +190,7 @@ def test_metadata_encoder(unencoded, encoded):
                                 "packages": {
                                     "package": {
                                         "has_cuda_suffix": True,
-                                        "has_nightly_builds": True,
+                                        "publishes_prereleases": True,
                                     },
                                 },
                             },
@@ -210,7 +210,7 @@ def test_metadata_encoder(unencoded, encoded):
                                 "packages": {
                                     "package": {
                                         "has_cuda_suffix": True,
-                                        "has_nightly_builds": True,
+                                        "publishes_prereleases": True,
                                     },
                                 },
                             },
@@ -222,7 +222,7 @@ def test_metadata_encoder(unencoded, encoded):
                                 "packages": {
                                     "package": {
                                         "has_cuda_suffix": True,
-                                        "has_nightly_builds": True,
+                                        "publishes_prereleases": True,
                                     },
                                 },
                             },

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -41,24 +41,24 @@ def set_cwd(cwd: os.PathLike) -> Generator:
 @pytest.mark.parametrize(
     ["unencoded", "encoded"],
     [
-        (RAPIDSPackage(), {"has_alpha_spec": True, "has_cuda_suffix": True}),
+        (RAPIDSPackage(), {"has_nightly_builds": True, "has_cuda_suffix": True}),
         (
             RAPIDSRepository(
                 packages={
                     "package1": RAPIDSPackage(),
                     "package2": RAPIDSPackage(
-                        has_alpha_spec=False, has_cuda_suffix=False
+                        has_nightly_builds=False, has_cuda_suffix=False
                     ),
                 }
             ),
             {
                 "packages": {
                     "package1": {
-                        "has_alpha_spec": True,
+                        "has_nightly_builds": True,
                         "has_cuda_suffix": True,
                     },
                     "package2": {
-                        "has_alpha_spec": False,
+                        "has_nightly_builds": False,
                         "has_cuda_suffix": False,
                     },
                 },
@@ -88,7 +88,7 @@ def set_cwd(cwd: os.PathLike) -> Generator:
                     "repo2": {
                         "packages": {
                             "package": {
-                                "has_alpha_spec": True,
+                                "has_nightly_builds": True,
                                 "has_cuda_suffix": True,
                             },
                         },
@@ -96,7 +96,7 @@ def set_cwd(cwd: os.PathLike) -> Generator:
                     "_nvidia": {
                         "packages": {
                             "proprietary-package": {
-                                "has_alpha_spec": True,
+                                "has_nightly_builds": True,
                                 "has_cuda_suffix": True,
                             },
                         },
@@ -150,7 +150,7 @@ def test_metadata_encoder(unencoded, encoded):
                                 "packages": {
                                     "package": {
                                         "has_cuda_suffix": True,
-                                        "has_alpha_spec": True,
+                                        "has_nightly_builds": True,
                                     },
                                 },
                             },
@@ -170,7 +170,7 @@ def test_metadata_encoder(unencoded, encoded):
                                 "packages": {
                                     "package": {
                                         "has_cuda_suffix": True,
-                                        "has_alpha_spec": True,
+                                        "has_nightly_builds": True,
                                     },
                                 },
                             },
@@ -190,7 +190,7 @@ def test_metadata_encoder(unencoded, encoded):
                                 "packages": {
                                     "package": {
                                         "has_cuda_suffix": True,
-                                        "has_alpha_spec": True,
+                                        "has_nightly_builds": True,
                                     },
                                 },
                             },
@@ -210,7 +210,7 @@ def test_metadata_encoder(unencoded, encoded):
                                 "packages": {
                                     "package": {
                                         "has_cuda_suffix": True,
-                                        "has_alpha_spec": True,
+                                        "has_nightly_builds": True,
                                     },
                                 },
                             },
@@ -222,7 +222,7 @@ def test_metadata_encoder(unencoded, encoded):
                                 "packages": {
                                     "package": {
                                         "has_cuda_suffix": True,
-                                        "has_alpha_spec": True,
+                                        "has_nightly_builds": True,
                                     },
                                 },
                             },


### PR DESCRIPTION
Requiring an alpha spec is not an inherent property of a package, but publishing prereleases is. Rename the field to more accurately reflect the nature of the underlying property.

Also move `test_json.py` to its proper directory.