### PR TITLE
rapids-dask-dependency has no CUDA suffix

### DIFF
--- a/src/rapids_metadata/__init__.py
+++ b/src/rapids_metadata/__init__.py
@@ -110,7 +110,7 @@ all_metadata.versions["24.08"] = RAPIDSVersion(
         ),
         "rapids-dask-dependency": RAPIDSRepository(
             packages={
-                "rapids-dask-dependency": RAPIDSPackage(),
+                "rapids-dask-dependency": RAPIDSPackage(has_cuda_suffix=False),
             }
         ),
         "rmm": RAPIDSRepository(


### PR DESCRIPTION
`rapids-dask-dependency` does not publish with a `-cu*` suffix. Set `has_cuda_suffix=False`.