### PR TITLE
Use Pydantic instead of asdict()

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,7 @@ repos:
         pass_filenames: false
         additional_dependencies:
           - packaging
+          - pydantic
   - repo: local
     hooks:
       - id: generate-json
@@ -50,6 +51,8 @@ repos:
         entry: ./ci/generate_json.py
         language: python
         pass_filenames: false
+        additional_dependencies:
+          - pydantic
 
 default_language_version:
       python: python3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "packaging",
+    "pydantic",
 ]
 
 [project.scripts]

--- a/src/rapids_metadata/json.py
+++ b/src/rapids_metadata/json.py
@@ -13,32 +13,21 @@
 # limitations under the License.
 
 import argparse
-import dataclasses
 import json
 import os
 import sys
-from typing import Any, Union
+from typing import Union
+
+from pydantic import TypeAdapter
 
 from . import all_metadata
-from .metadata import (
-    RAPIDSMetadata,
-    RAPIDSPackage,
-    RAPIDSRepository,
-    RAPIDSVersion,
-)
+from .metadata import RAPIDSMetadata
 from .rapids_version import get_rapids_version
 
 
 __all__ = [
     "main",
 ]
-
-
-class _RAPIDSMetadataEncoder(json.JSONEncoder):
-    def default(
-        self, o: Union[RAPIDSMetadata, RAPIDSPackage, RAPIDSRepository, RAPIDSVersion]
-    ) -> dict[str, Any]:
-        return dataclasses.asdict(o)
 
 
 def main(argv: Union[list[str], None] = None):
@@ -77,9 +66,8 @@ def main(argv: Union[list[str], None] = None):
 
     def write_file(f):
         json.dump(
-            metadata,
+            TypeAdapter(RAPIDSMetadata).dump_python(metadata),
             f,
-            cls=_RAPIDSMetadataEncoder,
             sort_keys=True,
             separators=(",", ": ") if parsed.pretty else (",", ":"),
             indent="  " if parsed.pretty else None,

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -19,6 +19,7 @@ from typing import Generator
 from unittest.mock import patch
 
 import pytest
+from pydantic import TypeAdapter
 from rapids_metadata import json as rapids_json
 from rapids_metadata.metadata import (
     RAPIDSMetadata,
@@ -133,7 +134,7 @@ def set_cwd(cwd: os.PathLike) -> Generator:
     ],
 )
 def test_metadata_encoder(unencoded, encoded):
-    assert rapids_json._RAPIDSMetadataEncoder().default(unencoded) == encoded
+    assert TypeAdapter(type(unencoded)).dump_python(unencoded) == encoded
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
We will use Pydantic later on for JSON decoding, so use it for encoding now.