### PR TITLE
Fix ptxcompiler and cubinlinker

### DIFF
--- a/rapids-metadata.json
+++ b/rapids-metadata.json
@@ -6,7 +6,7 @@
           "packages": {
             "cubinlinker": {
               "has_cuda_suffix": true,
-              "publishes_prereleases": true
+              "publishes_prereleases": false
             }
           }
         },
@@ -142,7 +142,7 @@
           "packages": {
             "ptxcompiler": {
               "has_cuda_suffix": true,
-              "publishes_prereleases": true
+              "publishes_prereleases": false
             }
           }
         },

--- a/src/rapids_metadata/__init__.py
+++ b/src/rapids_metadata/__init__.py
@@ -29,7 +29,7 @@ all_metadata.versions["24.08"] = RAPIDSVersion(
     repositories={
         "_nvidia": RAPIDSRepository(
             packages={
-                "cubinlinker": RAPIDSPackage(),
+                "cubinlinker": RAPIDSPackage(publishes_prereleases=False),
             }
         ),
         "cucim": RAPIDSRepository(
@@ -99,7 +99,7 @@ all_metadata.versions["24.08"] = RAPIDSVersion(
         ),
         "ptxcompiler": RAPIDSRepository(
             packages={
-                "ptxcompiler": RAPIDSPackage(),
+                "ptxcompiler": RAPIDSPackage(publishes_prereleases=False),
             }
         ),
         "pynvjitlink": RAPIDSRepository(


### PR DESCRIPTION
These packages do not publish prereleases, update metadata to reflect that.