### PR TITLE
Enable release wheels publish to pypi

### DIFF
--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -44,6 +44,7 @@ jobs:
     with:
       build_type: ${{ inputs.build_type }}
       package-name: rapids-metadata
+      publish_to_pypi: true
     if: ${{ inputs.publish }}
   publish-conda:
     needs:


### PR DESCRIPTION
Enables wheels publish to `pypi.org`.

NOTE: At the time of this PR, only wheels from release builds are published to PyPI. See https://github.com/rapidsai/shared-workflows/pull/225.