### PR TITLE
Update rapidsai/pre-commit-hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
         args: ["--fix"]
       - id: ruff-format
   - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: v0.1.0
+    rev: v0.4.0
     hooks:
       - id: verify-copyright
         args: [--fix, --main-branch=main]


### PR DESCRIPTION
This PR updates rapidsai/pre-commit-hooks to the version 0.4.0.
