### PR TITLE
move nx-cugraph to its own repo

### DIFF
--- a/rapids-metadata.json
+++ b/rapids-metadata.json
@@ -600,10 +600,6 @@
               "has_cuda_suffix": true,
               "publishes_prereleases": true
             },
-            "nx-cugraph": {
-              "has_cuda_suffix": true,
-              "publishes_prereleases": true
-            },
             "pylibcugraph": {
               "has_cuda_suffix": true,
               "publishes_prereleases": true
@@ -705,6 +701,14 @@
               "publishes_prereleases": true
             },
             "libkvikio": {
+              "has_cuda_suffix": true,
+              "publishes_prereleases": true
+            }
+          }
+        },
+        "nx-cugraph": {
+          "packages": {
+            "nx-cugraph": {
               "has_cuda_suffix": true,
               "publishes_prereleases": true
             }

--- a/src/rapids_metadata/__init__.py
+++ b/src/rapids_metadata/__init__.py
@@ -167,3 +167,10 @@ all_metadata.versions["24.10"].repositories["cuvs"] = RAPIDSRepository(
 )
 
 all_metadata.versions["24.12"] = deepcopy(all_metadata.versions["24.10"])
+
+del all_metadata.versions["24.12"].repositories["cugraph"].packages["nx-cugraph"]
+all_metadata.versions["24.12"].repositories["nx-cugraph"] = RAPIDSRepository(
+    packages={
+        "nx-cugraph": RAPIDSPackage(),
+    }
+)


### PR DESCRIPTION
In the 24.12 release, `nx-cugraph` is moving to its own repo:

* https://github.com/rapidsai/nx-cugraph
* https://github.com/rapidsai/cugraph/pull/4748

This updates the 24.12 metadata to reflect that.