### PR TITLE
move cugraph-dgl, cugraph-pyg, wholegraph to cugraph-gnn repo

### DIFF
--- a/rapids-metadata.json
+++ b/rapids-metadata.json
@@ -580,15 +580,7 @@
               "has_cuda_suffix": true,
               "publishes_prereleases": true
             },
-            "cugraph-dgl": {
-              "has_cuda_suffix": true,
-              "publishes_prereleases": true
-            },
             "cugraph-equivariant": {
-              "has_cuda_suffix": true,
-              "publishes_prereleases": true
-            },
-            "cugraph-pyg": {
               "has_cuda_suffix": true,
               "publishes_prereleases": true
             },
@@ -605,6 +597,22 @@
               "publishes_prereleases": true
             },
             "pylibcugraph": {
+              "has_cuda_suffix": true,
+              "publishes_prereleases": true
+            }
+          }
+        },
+        "cugraph-gnn": {
+          "packages": {
+            "cugraph-dgl": {
+              "has_cuda_suffix": true,
+              "publishes_prereleases": true
+            },
+            "cugraph-pyg": {
+              "has_cuda_suffix": true,
+              "publishes_prereleases": true
+            },
+            "pylibwholegraph": {
               "has_cuda_suffix": true,
               "publishes_prereleases": true
             }
@@ -785,14 +793,6 @@
               "publishes_prereleases": true
             },
             "ucxx": {
-              "has_cuda_suffix": true,
-              "publishes_prereleases": true
-            }
-          }
-        },
-        "wholegraph": {
-          "packages": {
-            "pylibwholegraph": {
               "has_cuda_suffix": true,
               "publishes_prereleases": true
             }

--- a/src/rapids_metadata/__init__.py
+++ b/src/rapids_metadata/__init__.py
@@ -167,3 +167,15 @@ all_metadata.versions["24.10"].repositories["cuvs"] = RAPIDSRepository(
 )
 
 all_metadata.versions["24.12"] = deepcopy(all_metadata.versions["24.10"])
+
+del all_metadata.versions["24.12"].repositories["cugraph"].packages["cugraph-dgl"]
+del all_metadata.versions["24.12"].repositories["cugraph"].packages["cugraph-pyg"]
+del all_metadata.versions["24.12"].repositories["wholegraph"]
+
+all_metadata.versions["24.12"].repositories["cugraph-gnn"] = RAPIDSRepository(
+    packages={
+        "cugraph-dgl": RAPIDSPackage(),
+        "cugraph-pyg": RAPIDSPackage(),
+        "pylibwholegraph": RAPIDSPackage(),
+    }
+)


### PR DESCRIPTION
Starting with RAPIDS 24.12, `cugraph-dgl`, `cugraph-pyg`, and `pylibwholegraph` are developed in a single new repo: https://github.com/rapidsai/cugraph-gnn

This proposes updating the 24.12 metadata to reflect that.

## Notes for Reviewers

This shouldn't be merged until all of the following are merged:

* [x] https://github.com/rapidsai/wholegraph/pull/233
* [x] https://github.com/rapidsai/cugraph/pull/4752
* [x] https://github.com/rapidsai/cugraph-gnn/pull/66

### Should this be combined with `nx-cugraph` changes?

No, let's keep it separate from https://github.com/rapidsai/rapids-metadata/pull/30.

They don't depend on each other, and those efforts are being managed by different people and moving forward separately.