### PR TITLE
remove cugraph-equivariant

### DIFF
--- a/rapids-metadata.json
+++ b/rapids-metadata.json
@@ -580,10 +580,6 @@
               "has_cuda_suffix": true,
               "publishes_prereleases": true
             },
-            "cugraph-equivariant": {
-              "has_cuda_suffix": true,
-              "publishes_prereleases": true
-            },
             "cugraph-service-client": {
               "has_cuda_suffix": false,
               "publishes_prereleases": true
@@ -853,10 +849,6 @@
         "cugraph": {
           "packages": {
             "cugraph": {
-              "has_cuda_suffix": true,
-              "publishes_prereleases": true
-            },
-            "cugraph-equivariant": {
               "has_cuda_suffix": true,
               "publishes_prereleases": true
             },

--- a/src/rapids_metadata/__init__.py
+++ b/src/rapids_metadata/__init__.py
@@ -168,10 +168,13 @@ all_metadata.versions["24.10"].repositories["cuvs"] = RAPIDSRepository(
 
 all_metadata.versions["24.12"] = deepcopy(all_metadata.versions["24.10"])
 
+# fmt: off
 del all_metadata.versions["24.12"].repositories["cugraph"].packages["cugraph-dgl"]
+del all_metadata.versions["24.12"].repositories["cugraph"].packages["cugraph-equivariant"]
 del all_metadata.versions["24.12"].repositories["cugraph"].packages["cugraph-pyg"]
 del all_metadata.versions["24.12"].repositories["cugraph"].packages["nx-cugraph"]
 del all_metadata.versions["24.12"].repositories["wholegraph"]
+# fmt: on
 
 all_metadata.versions["24.12"].repositories["cugraph-gnn"] = RAPIDSRepository(
     packages={


### PR DESCRIPTION
I learned yesterday that `cugraph-equivariance` is going to be completely removed in RAPIDS 24.12: https://github.com/rapidsai/cugraph/pull/4762

This proposes updating `rapids-metadata` accordingly.

Added a similar change for devcontainers too: https://github.com/rapidsai/devcontainers/pull/417