### PR TITLE
Add marker for conda packages and wheel packages and 24.12 updates

### DIFF
--- a/rapids-metadata.json
+++ b/rapids-metadata.json
@@ -6,6 +6,7 @@
           "packages": {
             "cubinlinker": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": false
             }
           }
@@ -14,6 +15,7 @@
           "packages": {
             "cucim": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -22,22 +24,27 @@
           "packages": {
             "cudf": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "cudf-polars": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "cudf_kafka": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "dask-cudf": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "libcudf": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -46,34 +53,42 @@
           "packages": {
             "cugraph": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "cugraph-dgl": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "cugraph-equivariant": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "cugraph-pyg": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "cugraph-service-client": {
               "has_cuda_suffix": false,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "cugraph-service-server": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "nx-cugraph": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "pylibcugraph": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -82,10 +97,12 @@
           "packages": {
             "libcugraphops": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "pylibcugraphops": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -94,14 +111,17 @@
           "packages": {
             "cuml": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "libcuml": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "libcuml-tests": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -110,6 +130,7 @@
           "packages": {
             "libcumlprims": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -118,6 +139,7 @@
           "packages": {
             "cuproj": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -126,14 +148,17 @@
           "packages": {
             "cuspatial": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "libcuspatial": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "libcuspatial-tests": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -142,6 +167,7 @@
           "packages": {
             "cuxfilter": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -150,6 +176,7 @@
           "packages": {
             "dask-cuda": {
               "has_cuda_suffix": false,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -158,10 +185,12 @@
           "packages": {
             "kvikio": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "libkvikio": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -170,6 +199,7 @@
           "packages": {
             "ptxcompiler": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": false
             }
           }
@@ -178,6 +208,7 @@
           "packages": {
             "pynvjitlink": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -186,18 +217,22 @@
           "packages": {
             "libraft": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "libraft-headers": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "pylibraft": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "raft-dask": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -206,6 +241,7 @@
           "packages": {
             "rapids-dask-dependency": {
               "has_cuda_suffix": false,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -214,10 +250,12 @@
           "packages": {
             "librmm": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "rmm": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -226,6 +264,7 @@
           "packages": {
             "ucx-py": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -234,14 +273,17 @@
           "packages": {
             "distributed-ucxx": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "libucxx": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "ucxx": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -250,6 +292,7 @@
           "packages": {
             "pylibwholegraph": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -262,6 +305,7 @@
           "packages": {
             "cubinlinker": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": false
             }
           }
@@ -270,6 +314,7 @@
           "packages": {
             "cucim": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -278,26 +323,32 @@
           "packages": {
             "cudf": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "cudf-polars": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "cudf_kafka": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "dask-cudf": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "libcudf": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "pylibcudf": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -306,34 +357,42 @@
           "packages": {
             "cugraph": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "cugraph-dgl": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "cugraph-equivariant": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "cugraph-pyg": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "cugraph-service-client": {
               "has_cuda_suffix": false,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "cugraph-service-server": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "nx-cugraph": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "pylibcugraph": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -342,10 +401,12 @@
           "packages": {
             "libcugraphops": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "pylibcugraphops": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -354,14 +415,17 @@
           "packages": {
             "cuml": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "libcuml": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "libcuml-tests": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -370,6 +434,7 @@
           "packages": {
             "libcumlprims": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -378,6 +443,7 @@
           "packages": {
             "cuproj": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -386,14 +452,17 @@
           "packages": {
             "cuspatial": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "libcuspatial": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "libcuspatial-tests": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -402,10 +471,12 @@
           "packages": {
             "cuvs": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "libcuvs": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -414,6 +485,7 @@
           "packages": {
             "cuxfilter": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -422,6 +494,7 @@
           "packages": {
             "dask-cuda": {
               "has_cuda_suffix": false,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -430,10 +503,12 @@
           "packages": {
             "kvikio": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "libkvikio": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -442,6 +517,7 @@
           "packages": {
             "ptxcompiler": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": false
             }
           }
@@ -450,6 +526,7 @@
           "packages": {
             "pynvjitlink": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -458,18 +535,22 @@
           "packages": {
             "libraft": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "libraft-headers": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "pylibraft": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "raft-dask": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -478,6 +559,7 @@
           "packages": {
             "rapids-dask-dependency": {
               "has_cuda_suffix": false,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -486,10 +568,12 @@
           "packages": {
             "librmm": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "rmm": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -498,6 +582,7 @@
           "packages": {
             "ucx-py": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -506,14 +591,17 @@
           "packages": {
             "distributed-ucxx": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "libucxx": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "ucxx": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -522,6 +610,7 @@
           "packages": {
             "pylibwholegraph": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -534,6 +623,7 @@
           "packages": {
             "cubinlinker": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": false
             }
           }
@@ -542,6 +632,7 @@
           "packages": {
             "cucim": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -550,26 +641,32 @@
           "packages": {
             "cudf": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "cudf-polars": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "cudf_kafka": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "dask-cudf": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "libcudf": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "pylibcudf": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -578,18 +675,22 @@
           "packages": {
             "cugraph": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "cugraph-service-client": {
               "has_cuda_suffix": false,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "cugraph-service-server": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "pylibcugraph": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -598,14 +699,17 @@
           "packages": {
             "cugraph-dgl": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "cugraph-pyg": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "pylibwholegraph": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -614,10 +718,12 @@
           "packages": {
             "libcugraphops": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "pylibcugraphops": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -626,14 +732,17 @@
           "packages": {
             "cuml": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "libcuml": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "libcuml-tests": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -642,6 +751,7 @@
           "packages": {
             "libcumlprims": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -650,6 +760,7 @@
           "packages": {
             "cuproj": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -658,14 +769,17 @@
           "packages": {
             "cuspatial": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "libcuspatial": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "libcuspatial-tests": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -674,10 +788,12 @@
           "packages": {
             "cuvs": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "libcuvs": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -686,6 +802,7 @@
           "packages": {
             "cuxfilter": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -694,6 +811,7 @@
           "packages": {
             "dask-cuda": {
               "has_cuda_suffix": false,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -702,10 +820,12 @@
           "packages": {
             "kvikio": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "libkvikio": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -714,6 +834,7 @@
           "packages": {
             "nx-cugraph": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -722,6 +843,7 @@
           "packages": {
             "ptxcompiler": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": false
             }
           }
@@ -730,6 +852,7 @@
           "packages": {
             "pynvjitlink": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -738,18 +861,22 @@
           "packages": {
             "libraft": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "libraft-headers": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "pylibraft": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "raft-dask": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -758,6 +885,7 @@
           "packages": {
             "rapids-dask-dependency": {
               "has_cuda_suffix": false,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -766,10 +894,12 @@
           "packages": {
             "librmm": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "rmm": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -778,6 +908,7 @@
           "packages": {
             "ucx-py": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -786,14 +917,17 @@
           "packages": {
             "distributed-ucxx": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "libucxx": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "ucxx": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -806,6 +940,7 @@
           "packages": {
             "cubinlinker": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": false
             }
           }
@@ -814,6 +949,7 @@
           "packages": {
             "cucim": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -822,26 +958,32 @@
           "packages": {
             "cudf": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "cudf-polars": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "cudf_kafka": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "dask-cudf": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "libcudf": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "pylibcudf": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -850,18 +992,22 @@
           "packages": {
             "cugraph": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "cugraph-service-client": {
               "has_cuda_suffix": false,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "cugraph-service-server": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "pylibcugraph": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -870,14 +1016,17 @@
           "packages": {
             "cugraph-dgl": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "cugraph-pyg": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "pylibwholegraph": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -886,10 +1035,12 @@
           "packages": {
             "libcugraphops": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "pylibcugraphops": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -898,14 +1049,17 @@
           "packages": {
             "cuml": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "libcuml": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "libcuml-tests": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -914,6 +1068,7 @@
           "packages": {
             "libcumlprims": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -922,6 +1077,7 @@
           "packages": {
             "cuproj": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -930,14 +1086,17 @@
           "packages": {
             "cuspatial": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "libcuspatial": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "libcuspatial-tests": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -946,10 +1105,12 @@
           "packages": {
             "cuvs": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "libcuvs": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -958,6 +1119,7 @@
           "packages": {
             "cuxfilter": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -966,6 +1128,7 @@
           "packages": {
             "dask-cuda": {
               "has_cuda_suffix": false,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -974,10 +1137,12 @@
           "packages": {
             "kvikio": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "libkvikio": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -986,6 +1151,7 @@
           "packages": {
             "nx-cugraph": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -994,6 +1160,7 @@
           "packages": {
             "ptxcompiler": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": false
             }
           }
@@ -1002,6 +1169,7 @@
           "packages": {
             "pynvjitlink": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -1010,18 +1178,22 @@
           "packages": {
             "libraft": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "libraft-headers": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "pylibraft": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "raft-dask": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -1030,6 +1202,7 @@
           "packages": {
             "rapids-dask-dependency": {
               "has_cuda_suffix": false,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -1038,10 +1211,12 @@
           "packages": {
             "librmm": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "rmm": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -1050,6 +1225,7 @@
           "packages": {
             "ucx-py": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }
@@ -1058,14 +1234,17 @@
           "packages": {
             "distributed-ucxx": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "libucxx": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             },
             "ucxx": {
               "has_cuda_suffix": true,
+              "is_conda_only": false,
               "publishes_prereleases": true
             }
           }

--- a/rapids-metadata.json
+++ b/rapids-metadata.json
@@ -17,6 +17,11 @@
               "has_cuda_suffix": true,
               "is_conda_only": false,
               "publishes_prereleases": true
+            },
+            "libcucim": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
+              "publishes_prereleases": true
             }
           }
         },
@@ -37,6 +42,11 @@
               "is_conda_only": false,
               "publishes_prereleases": true
             },
+            "custreamz": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
+              "publishes_prereleases": true
+            },
             "dask-cudf": {
               "has_cuda_suffix": true,
               "is_conda_only": false,
@@ -45,6 +55,11 @@
             "libcudf": {
               "has_cuda_suffix": true,
               "is_conda_only": false,
+              "publishes_prereleases": true
+            },
+            "libcudf_kafka": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
               "publishes_prereleases": true
             }
           }
@@ -73,12 +88,22 @@
             },
             "cugraph-service-client": {
               "has_cuda_suffix": false,
-              "is_conda_only": false,
+              "is_conda_only": true,
               "publishes_prereleases": true
             },
             "cugraph-service-server": {
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "is_conda_only": true,
+              "publishes_prereleases": true
+            },
+            "libcugraph": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
+              "publishes_prereleases": true
+            },
+            "libcugraph_etl": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
               "publishes_prereleases": true
             },
             "nx-cugraph": {
@@ -114,14 +139,19 @@
               "is_conda_only": false,
               "publishes_prereleases": true
             },
+            "cuml-cpu": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
+              "publishes_prereleases": true
+            },
             "libcuml": {
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "is_conda_only": true,
               "publishes_prereleases": true
             },
             "libcuml-tests": {
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "is_conda_only": true,
               "publishes_prereleases": true
             }
           }
@@ -158,7 +188,7 @@
             },
             "libcuspatial-tests": {
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "is_conda_only": true,
               "publishes_prereleases": true
             }
           }
@@ -225,9 +255,29 @@
               "is_conda_only": false,
               "publishes_prereleases": true
             },
+            "libraft-headers-only": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
+              "publishes_prereleases": true
+            },
+            "libraft-static": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
+              "publishes_prereleases": true
+            },
             "pylibraft": {
               "has_cuda_suffix": true,
               "is_conda_only": false,
+              "publishes_prereleases": true
+            },
+            "raft-ann-bench": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
+              "publishes_prereleases": true
+            },
+            "raft-ann-bench-cpu": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
               "publishes_prereleases": true
             },
             "raft-dask": {
@@ -290,6 +340,11 @@
         },
         "wholegraph": {
           "packages": {
+            "libwholegraph": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
+              "publishes_prereleases": true
+            },
             "pylibwholegraph": {
               "has_cuda_suffix": true,
               "is_conda_only": false,
@@ -316,6 +371,11 @@
               "has_cuda_suffix": true,
               "is_conda_only": false,
               "publishes_prereleases": true
+            },
+            "libcucim": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
+              "publishes_prereleases": true
             }
           }
         },
@@ -336,6 +396,11 @@
               "is_conda_only": false,
               "publishes_prereleases": true
             },
+            "custreamz": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
+              "publishes_prereleases": true
+            },
             "dask-cudf": {
               "has_cuda_suffix": true,
               "is_conda_only": false,
@@ -344,6 +409,11 @@
             "libcudf": {
               "has_cuda_suffix": true,
               "is_conda_only": false,
+              "publishes_prereleases": true
+            },
+            "libcudf_kafka": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
               "publishes_prereleases": true
             },
             "pylibcudf": {
@@ -377,12 +447,22 @@
             },
             "cugraph-service-client": {
               "has_cuda_suffix": false,
-              "is_conda_only": false,
+              "is_conda_only": true,
               "publishes_prereleases": true
             },
             "cugraph-service-server": {
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "is_conda_only": true,
+              "publishes_prereleases": true
+            },
+            "libcugraph": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
+              "publishes_prereleases": true
+            },
+            "libcugraph_etl": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
               "publishes_prereleases": true
             },
             "nx-cugraph": {
@@ -418,14 +498,19 @@
               "is_conda_only": false,
               "publishes_prereleases": true
             },
+            "cuml-cpu": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
+              "publishes_prereleases": true
+            },
             "libcuml": {
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "is_conda_only": true,
               "publishes_prereleases": true
             },
             "libcuml-tests": {
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "is_conda_only": true,
               "publishes_prereleases": true
             }
           }
@@ -462,7 +547,7 @@
             },
             "libcuspatial-tests": {
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "is_conda_only": true,
               "publishes_prereleases": true
             }
           }
@@ -476,7 +561,7 @@
             },
             "libcuvs": {
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "is_conda_only": true,
               "publishes_prereleases": true
             }
           }
@@ -543,9 +628,29 @@
               "is_conda_only": false,
               "publishes_prereleases": true
             },
+            "libraft-headers-only": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
+              "publishes_prereleases": true
+            },
+            "libraft-static": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
+              "publishes_prereleases": true
+            },
             "pylibraft": {
               "has_cuda_suffix": true,
               "is_conda_only": false,
+              "publishes_prereleases": true
+            },
+            "raft-ann-bench": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
+              "publishes_prereleases": true
+            },
+            "raft-ann-bench-cpu": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
               "publishes_prereleases": true
             },
             "raft-dask": {
@@ -608,6 +713,11 @@
         },
         "wholegraph": {
           "packages": {
+            "libwholegraph": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
+              "publishes_prereleases": true
+            },
             "pylibwholegraph": {
               "has_cuda_suffix": true,
               "is_conda_only": false,
@@ -634,6 +744,11 @@
               "has_cuda_suffix": true,
               "is_conda_only": false,
               "publishes_prereleases": true
+            },
+            "libcucim": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
+              "publishes_prereleases": true
             }
           }
         },
@@ -654,6 +769,11 @@
               "is_conda_only": false,
               "publishes_prereleases": true
             },
+            "custreamz": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
+              "publishes_prereleases": true
+            },
             "dask-cudf": {
               "has_cuda_suffix": true,
               "is_conda_only": false,
@@ -662,6 +782,11 @@
             "libcudf": {
               "has_cuda_suffix": true,
               "is_conda_only": false,
+              "publishes_prereleases": true
+            },
+            "libcudf_kafka": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
               "publishes_prereleases": true
             },
             "pylibcudf": {
@@ -680,12 +805,22 @@
             },
             "cugraph-service-client": {
               "has_cuda_suffix": false,
-              "is_conda_only": false,
+              "is_conda_only": true,
               "publishes_prereleases": true
             },
             "cugraph-service-server": {
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "is_conda_only": true,
+              "publishes_prereleases": true
+            },
+            "libcugraph": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
+              "publishes_prereleases": true
+            },
+            "libcugraph_etl": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
               "publishes_prereleases": true
             },
             "pylibcugraph": {
@@ -705,6 +840,11 @@
             "cugraph-pyg": {
               "has_cuda_suffix": true,
               "is_conda_only": false,
+              "publishes_prereleases": true
+            },
+            "libwholegraph": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
               "publishes_prereleases": true
             },
             "pylibwholegraph": {
@@ -735,14 +875,19 @@
               "is_conda_only": false,
               "publishes_prereleases": true
             },
+            "cuml-cpu": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
+              "publishes_prereleases": true
+            },
             "libcuml": {
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "is_conda_only": true,
               "publishes_prereleases": true
             },
             "libcuml-tests": {
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "is_conda_only": true,
               "publishes_prereleases": true
             }
           }
@@ -779,7 +924,7 @@
             },
             "libcuspatial-tests": {
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "is_conda_only": true,
               "publishes_prereleases": true
             }
           }
@@ -791,9 +936,24 @@
               "is_conda_only": false,
               "publishes_prereleases": true
             },
+            "cuvs-bench": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
+              "publishes_prereleases": true
+            },
+            "cuvs-bench-cpu": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
+              "publishes_prereleases": true
+            },
             "libcuvs": {
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "is_conda_only": true,
+              "publishes_prereleases": true
+            },
+            "libcuvs-static": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
               "publishes_prereleases": true
             }
           }
@@ -867,6 +1027,16 @@
             "libraft-headers": {
               "has_cuda_suffix": true,
               "is_conda_only": false,
+              "publishes_prereleases": true
+            },
+            "libraft-headers-only": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
+              "publishes_prereleases": true
+            },
+            "libraft-static": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
               "publishes_prereleases": true
             },
             "pylibraft": {
@@ -951,6 +1121,11 @@
               "has_cuda_suffix": true,
               "is_conda_only": false,
               "publishes_prereleases": true
+            },
+            "libcucim": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
+              "publishes_prereleases": true
             }
           }
         },
@@ -971,6 +1146,11 @@
               "is_conda_only": false,
               "publishes_prereleases": true
             },
+            "custreamz": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
+              "publishes_prereleases": true
+            },
             "dask-cudf": {
               "has_cuda_suffix": true,
               "is_conda_only": false,
@@ -979,6 +1159,11 @@
             "libcudf": {
               "has_cuda_suffix": true,
               "is_conda_only": false,
+              "publishes_prereleases": true
+            },
+            "libcudf_kafka": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
               "publishes_prereleases": true
             },
             "pylibcudf": {
@@ -997,12 +1182,22 @@
             },
             "cugraph-service-client": {
               "has_cuda_suffix": false,
-              "is_conda_only": false,
+              "is_conda_only": true,
               "publishes_prereleases": true
             },
             "cugraph-service-server": {
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "is_conda_only": true,
+              "publishes_prereleases": true
+            },
+            "libcugraph": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
+              "publishes_prereleases": true
+            },
+            "libcugraph_etl": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
               "publishes_prereleases": true
             },
             "pylibcugraph": {
@@ -1022,6 +1217,11 @@
             "cugraph-pyg": {
               "has_cuda_suffix": true,
               "is_conda_only": false,
+              "publishes_prereleases": true
+            },
+            "libwholegraph": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
               "publishes_prereleases": true
             },
             "pylibwholegraph": {
@@ -1052,14 +1252,19 @@
               "is_conda_only": false,
               "publishes_prereleases": true
             },
+            "cuml-cpu": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
+              "publishes_prereleases": true
+            },
             "libcuml": {
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "is_conda_only": true,
               "publishes_prereleases": true
             },
             "libcuml-tests": {
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "is_conda_only": true,
               "publishes_prereleases": true
             }
           }
@@ -1096,7 +1301,7 @@
             },
             "libcuspatial-tests": {
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "is_conda_only": true,
               "publishes_prereleases": true
             }
           }
@@ -1108,9 +1313,24 @@
               "is_conda_only": false,
               "publishes_prereleases": true
             },
+            "cuvs-bench": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
+              "publishes_prereleases": true
+            },
+            "cuvs-bench-cpu": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
+              "publishes_prereleases": true
+            },
             "libcuvs": {
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "is_conda_only": true,
+              "publishes_prereleases": true
+            },
+            "libcuvs-static": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
               "publishes_prereleases": true
             }
           }
@@ -1184,6 +1404,16 @@
             "libraft-headers": {
               "has_cuda_suffix": true,
               "is_conda_only": false,
+              "publishes_prereleases": true
+            },
+            "libraft-headers-only": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
+              "publishes_prereleases": true
+            },
+            "libraft-static": {
+              "has_cuda_suffix": true,
+              "is_conda_only": true,
               "publishes_prereleases": true
             },
             "pylibraft": {

--- a/rapids-metadata.json
+++ b/rapids-metadata.json
@@ -5,8 +5,9 @@
         "_nvidia": {
           "packages": {
             "cubinlinker": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": false
             }
           }
@@ -14,13 +15,15 @@
         "cucim": {
           "packages": {
             "cucim": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libcucim": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             }
           }
@@ -28,38 +31,45 @@
         "cudf": {
           "packages": {
             "cudf": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "cudf-polars": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "cudf_kafka": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "custreamz": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "dask-cudf": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libcudf": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libcudf_kafka": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             }
           }
@@ -67,53 +77,63 @@
         "cugraph": {
           "packages": {
             "cugraph": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "cugraph-dgl": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "cugraph-equivariant": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "cugraph-pyg": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "cugraph-service-client": {
+              "has_conda_package": true,
               "has_cuda_suffix": false,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "cugraph-service-server": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "libcugraph": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "libcugraph_etl": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "nx-cugraph": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "pylibcugraph": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -121,13 +141,15 @@
         "cugraph-ops": {
           "packages": {
             "libcugraphops": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "pylibcugraphops": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -135,23 +157,27 @@
         "cuml": {
           "packages": {
             "cuml": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "cuml-cpu": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "libcuml": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "libcuml-tests": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             }
           }
@@ -159,8 +185,9 @@
         "cumlprims_mg": {
           "packages": {
             "libcumlprims": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -168,8 +195,9 @@
         "cuproj": {
           "packages": {
             "cuproj": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -177,18 +205,21 @@
         "cuspatial": {
           "packages": {
             "cuspatial": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libcuspatial": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libcuspatial-tests": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             }
           }
@@ -196,8 +227,9 @@
         "cuxfilter": {
           "packages": {
             "cuxfilter": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -205,8 +237,9 @@
         "dask-cuda": {
           "packages": {
             "dask-cuda": {
+              "has_conda_package": true,
               "has_cuda_suffix": false,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -214,13 +247,15 @@
         "kvikio": {
           "packages": {
             "kvikio": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libkvikio": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -228,8 +263,9 @@
         "ptxcompiler": {
           "packages": {
             "ptxcompiler": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": false
             }
           }
@@ -237,8 +273,9 @@
         "pynvjitlink": {
           "packages": {
             "pynvjitlink": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -246,43 +283,51 @@
         "raft": {
           "packages": {
             "libraft": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libraft-headers": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libraft-headers-only": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "libraft-static": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "pylibraft": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "raft-ann-bench": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "raft-ann-bench-cpu": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "raft-dask": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -290,8 +335,9 @@
         "rapids-dask-dependency": {
           "packages": {
             "rapids-dask-dependency": {
+              "has_conda_package": true,
               "has_cuda_suffix": false,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -299,13 +345,15 @@
         "rmm": {
           "packages": {
             "librmm": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "rmm": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -313,8 +361,9 @@
         "ucx-py": {
           "packages": {
             "ucx-py": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -322,18 +371,21 @@
         "ucxx": {
           "packages": {
             "distributed-ucxx": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libucxx": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "ucxx": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -341,13 +393,15 @@
         "wholegraph": {
           "packages": {
             "libwholegraph": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "pylibwholegraph": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -359,8 +413,9 @@
         "_nvidia": {
           "packages": {
             "cubinlinker": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": false
             }
           }
@@ -368,13 +423,15 @@
         "cucim": {
           "packages": {
             "cucim": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libcucim": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             }
           }
@@ -382,43 +439,51 @@
         "cudf": {
           "packages": {
             "cudf": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "cudf-polars": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "cudf_kafka": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "custreamz": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "dask-cudf": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libcudf": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libcudf_kafka": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "pylibcudf": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -426,53 +491,63 @@
         "cugraph": {
           "packages": {
             "cugraph": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "cugraph-dgl": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "cugraph-equivariant": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "cugraph-pyg": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "cugraph-service-client": {
+              "has_conda_package": true,
               "has_cuda_suffix": false,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "cugraph-service-server": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "libcugraph": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "libcugraph_etl": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "nx-cugraph": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "pylibcugraph": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -480,13 +555,15 @@
         "cugraph-ops": {
           "packages": {
             "libcugraphops": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "pylibcugraphops": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -494,23 +571,27 @@
         "cuml": {
           "packages": {
             "cuml": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "cuml-cpu": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "libcuml": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "libcuml-tests": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             }
           }
@@ -518,8 +599,9 @@
         "cumlprims_mg": {
           "packages": {
             "libcumlprims": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -527,8 +609,9 @@
         "cuproj": {
           "packages": {
             "cuproj": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -536,18 +619,21 @@
         "cuspatial": {
           "packages": {
             "cuspatial": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libcuspatial": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libcuspatial-tests": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             }
           }
@@ -555,13 +641,15 @@
         "cuvs": {
           "packages": {
             "cuvs": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libcuvs": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             }
           }
@@ -569,8 +657,9 @@
         "cuxfilter": {
           "packages": {
             "cuxfilter": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -578,8 +667,9 @@
         "dask-cuda": {
           "packages": {
             "dask-cuda": {
+              "has_conda_package": true,
               "has_cuda_suffix": false,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -587,13 +677,15 @@
         "kvikio": {
           "packages": {
             "kvikio": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libkvikio": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -601,8 +693,9 @@
         "ptxcompiler": {
           "packages": {
             "ptxcompiler": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": false
             }
           }
@@ -610,8 +703,9 @@
         "pynvjitlink": {
           "packages": {
             "pynvjitlink": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -619,43 +713,51 @@
         "raft": {
           "packages": {
             "libraft": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libraft-headers": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libraft-headers-only": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "libraft-static": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "pylibraft": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "raft-ann-bench": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "raft-ann-bench-cpu": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "raft-dask": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -663,8 +765,9 @@
         "rapids-dask-dependency": {
           "packages": {
             "rapids-dask-dependency": {
+              "has_conda_package": true,
               "has_cuda_suffix": false,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -672,13 +775,15 @@
         "rmm": {
           "packages": {
             "librmm": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "rmm": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -686,8 +791,9 @@
         "ucx-py": {
           "packages": {
             "ucx-py": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -695,18 +801,21 @@
         "ucxx": {
           "packages": {
             "distributed-ucxx": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libucxx": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "ucxx": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -714,13 +823,15 @@
         "wholegraph": {
           "packages": {
             "libwholegraph": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "pylibwholegraph": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -732,8 +843,9 @@
         "_nvidia": {
           "packages": {
             "cubinlinker": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": false
             }
           }
@@ -741,13 +853,15 @@
         "cucim": {
           "packages": {
             "cucim": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libcucim": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             }
           }
@@ -755,43 +869,51 @@
         "cudf": {
           "packages": {
             "cudf": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "cudf-polars": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "cudf_kafka": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "custreamz": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "dask-cudf": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libcudf": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libcudf_kafka": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "pylibcudf": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -799,33 +921,39 @@
         "cugraph": {
           "packages": {
             "cugraph": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "cugraph-service-client": {
+              "has_conda_package": true,
               "has_cuda_suffix": false,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "cugraph-service-server": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "libcugraph": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "libcugraph_etl": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "pylibcugraph": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -833,23 +961,27 @@
         "cugraph-gnn": {
           "packages": {
             "cugraph-dgl": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "cugraph-pyg": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libwholegraph": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "pylibwholegraph": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -857,13 +989,15 @@
         "cugraph-ops": {
           "packages": {
             "libcugraphops": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "pylibcugraphops": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -871,23 +1005,27 @@
         "cuml": {
           "packages": {
             "cuml": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "cuml-cpu": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "libcuml": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "libcuml-tests": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             }
           }
@@ -895,8 +1033,9 @@
         "cumlprims_mg": {
           "packages": {
             "libcumlprims": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -904,8 +1043,9 @@
         "cuproj": {
           "packages": {
             "cuproj": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -913,18 +1053,21 @@
         "cuspatial": {
           "packages": {
             "cuspatial": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libcuspatial": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libcuspatial-tests": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             }
           }
@@ -932,28 +1075,33 @@
         "cuvs": {
           "packages": {
             "cuvs": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "cuvs-bench": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "cuvs-bench-cpu": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "libcuvs": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "libcuvs-static": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             }
           }
@@ -961,8 +1109,9 @@
         "cuxfilter": {
           "packages": {
             "cuxfilter": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -970,8 +1119,9 @@
         "dask-cuda": {
           "packages": {
             "dask-cuda": {
+              "has_conda_package": true,
               "has_cuda_suffix": false,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -979,13 +1129,15 @@
         "kvikio": {
           "packages": {
             "kvikio": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libkvikio": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -993,8 +1145,9 @@
         "nx-cugraph": {
           "packages": {
             "nx-cugraph": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -1002,8 +1155,9 @@
         "ptxcompiler": {
           "packages": {
             "ptxcompiler": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": false
             }
           }
@@ -1011,8 +1165,9 @@
         "pynvjitlink": {
           "packages": {
             "pynvjitlink": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -1020,33 +1175,39 @@
         "raft": {
           "packages": {
             "libraft": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libraft-headers": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libraft-headers-only": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "libraft-static": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "pylibraft": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "raft-dask": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -1054,8 +1215,9 @@
         "rapids-dask-dependency": {
           "packages": {
             "rapids-dask-dependency": {
+              "has_conda_package": true,
               "has_cuda_suffix": false,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -1063,13 +1225,15 @@
         "rmm": {
           "packages": {
             "librmm": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "rmm": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -1077,8 +1241,9 @@
         "ucx-py": {
           "packages": {
             "ucx-py": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -1086,18 +1251,21 @@
         "ucxx": {
           "packages": {
             "distributed-ucxx": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libucxx": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "ucxx": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -1109,8 +1277,9 @@
         "_nvidia": {
           "packages": {
             "cubinlinker": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": false
             }
           }
@@ -1118,13 +1287,15 @@
         "cucim": {
           "packages": {
             "cucim": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libcucim": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             }
           }
@@ -1132,43 +1303,51 @@
         "cudf": {
           "packages": {
             "cudf": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "cudf-polars": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "cudf_kafka": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "custreamz": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "dask-cudf": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libcudf": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libcudf_kafka": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "pylibcudf": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -1176,33 +1355,39 @@
         "cugraph": {
           "packages": {
             "cugraph": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "cugraph-service-client": {
+              "has_conda_package": true,
               "has_cuda_suffix": false,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "cugraph-service-server": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "libcugraph": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "libcugraph_etl": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "pylibcugraph": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -1210,23 +1395,27 @@
         "cugraph-gnn": {
           "packages": {
             "cugraph-dgl": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "cugraph-pyg": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libwholegraph": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "pylibwholegraph": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -1234,13 +1423,15 @@
         "cugraph-ops": {
           "packages": {
             "libcugraphops": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "pylibcugraphops": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -1248,23 +1439,27 @@
         "cuml": {
           "packages": {
             "cuml": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "cuml-cpu": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "libcuml": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "libcuml-tests": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             }
           }
@@ -1272,8 +1467,9 @@
         "cumlprims_mg": {
           "packages": {
             "libcumlprims": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -1281,8 +1477,9 @@
         "cuproj": {
           "packages": {
             "cuproj": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -1290,18 +1487,21 @@
         "cuspatial": {
           "packages": {
             "cuspatial": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libcuspatial": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libcuspatial-tests": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             }
           }
@@ -1309,28 +1509,33 @@
         "cuvs": {
           "packages": {
             "cuvs": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "cuvs-bench": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "cuvs-bench-cpu": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "libcuvs": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "libcuvs-static": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             }
           }
@@ -1338,8 +1543,9 @@
         "cuxfilter": {
           "packages": {
             "cuxfilter": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -1347,8 +1553,9 @@
         "dask-cuda": {
           "packages": {
             "dask-cuda": {
+              "has_conda_package": true,
               "has_cuda_suffix": false,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -1356,13 +1563,15 @@
         "kvikio": {
           "packages": {
             "kvikio": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libkvikio": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -1370,8 +1579,9 @@
         "nx-cugraph": {
           "packages": {
             "nx-cugraph": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -1379,8 +1589,9 @@
         "ptxcompiler": {
           "packages": {
             "ptxcompiler": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": false
             }
           }
@@ -1388,8 +1599,9 @@
         "pynvjitlink": {
           "packages": {
             "pynvjitlink": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -1397,33 +1609,39 @@
         "raft": {
           "packages": {
             "libraft": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libraft-headers": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libraft-headers-only": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "libraft-static": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "pylibraft": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "raft-dask": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -1431,8 +1649,9 @@
         "rapids-dask-dependency": {
           "packages": {
             "rapids-dask-dependency": {
+              "has_conda_package": true,
               "has_cuda_suffix": false,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -1440,13 +1659,15 @@
         "rmm": {
           "packages": {
             "librmm": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "rmm": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -1454,8 +1675,9 @@
         "ucx-py": {
           "packages": {
             "ucx-py": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }
@@ -1463,18 +1685,21 @@
         "ucxx": {
           "packages": {
             "distributed-ucxx": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libucxx": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "ucxx": {
+              "has_conda_package": true,
               "has_cuda_suffix": true,
-              "is_conda_only": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             }
           }

--- a/schemas/rapids-metadata-v1.json
+++ b/schemas/rapids-metadata-v1.json
@@ -3,16 +3,22 @@
     "RAPIDSPackage": {
       "description": "Package published by a RAPIDS repository. Includes both Python packages and Conda packages.",
       "properties": {
+        "has_conda_package": {
+          "default": true,
+          "description": "Whether or not the package exists as a conda package.",
+          "title": "Has Conda Package",
+          "type": "boolean"
+        },
         "has_cuda_suffix": {
           "default": true,
           "description": "Whether or not the package has a CUDA suffix.",
           "title": "Has Cuda Suffix",
           "type": "boolean"
         },
-        "is_conda_only": {
-          "default": false,
-          "description": "Whether or not the package exists only as a conda package.",
-          "title": "Is Conda Only",
+        "has_wheel_package": {
+          "default": true,
+          "description": "Whether or not the package exists as a wheel package.",
+          "title": "Has Wheel Package",
           "type": "boolean"
         },
         "publishes_prereleases": {

--- a/schemas/rapids-metadata-v1.json
+++ b/schemas/rapids-metadata-v1.json
@@ -9,6 +9,12 @@
           "title": "Has Cuda Suffix",
           "type": "boolean"
         },
+        "is_conda_only": {
+          "default": false,
+          "description": "Whether or not the package exists only as a conda package.",
+          "title": "Is Conda Only",
+          "type": "boolean"
+        },
         "publishes_prereleases": {
           "default": true,
           "description": "Whether or not the package publishes prereleases.",

--- a/src/rapids_metadata/__init__.py
+++ b/src/rapids_metadata/__init__.py
@@ -37,6 +37,7 @@ all_metadata.versions["24.08"] = RAPIDSVersion(
         "cucim": RAPIDSRepository(
             packages={
                 "cucim": RAPIDSPackage(),
+                "libcucim": RAPIDSPackage(is_conda_only=True),
             }
         ),
         "cudf": RAPIDSRepository(
@@ -44,8 +45,10 @@ all_metadata.versions["24.08"] = RAPIDSVersion(
                 "cudf": RAPIDSPackage(),
                 "cudf-polars": RAPIDSPackage(),
                 "cudf_kafka": RAPIDSPackage(),
+                "custreamz": RAPIDSPackage(is_conda_only=True),
                 "dask-cudf": RAPIDSPackage(),
                 "libcudf": RAPIDSPackage(),
+                "libcudf_kafka": RAPIDSPackage(is_conda_only=True),
             }
         ),
         "cugraph": RAPIDSRepository(
@@ -54,8 +57,12 @@ all_metadata.versions["24.08"] = RAPIDSVersion(
                 "cugraph-dgl": RAPIDSPackage(),
                 "cugraph-equivariant": RAPIDSPackage(),
                 "cugraph-pyg": RAPIDSPackage(),
-                "cugraph-service-client": RAPIDSPackage(has_cuda_suffix=False),
-                "cugraph-service-server": RAPIDSPackage(),
+                "cugraph-service-client": RAPIDSPackage(
+                    has_cuda_suffix=False, is_conda_only=True
+                ),
+                "cugraph-service-server": RAPIDSPackage(is_conda_only=True),
+                "libcugraph": RAPIDSPackage(is_conda_only=True),
+                "libcugraph_etl": RAPIDSPackage(is_conda_only=True),
                 "nx-cugraph": RAPIDSPackage(),
                 "pylibcugraph": RAPIDSPackage(),
             }
@@ -69,8 +76,9 @@ all_metadata.versions["24.08"] = RAPIDSVersion(
         "cuml": RAPIDSRepository(
             packages={
                 "cuml": RAPIDSPackage(),
-                "libcuml": RAPIDSPackage(),
-                "libcuml-tests": RAPIDSPackage(),
+                "cuml-cpu": RAPIDSPackage(is_conda_only=True),
+                "libcuml": RAPIDSPackage(is_conda_only=True),
+                "libcuml-tests": RAPIDSPackage(is_conda_only=True),
             }
         ),
         "cumlprims_mg": RAPIDSRepository(
@@ -87,7 +95,7 @@ all_metadata.versions["24.08"] = RAPIDSVersion(
             packages={
                 "cuspatial": RAPIDSPackage(),
                 "libcuspatial": RAPIDSPackage(),
-                "libcuspatial-tests": RAPIDSPackage(),
+                "libcuspatial-tests": RAPIDSPackage(is_conda_only=True),
             }
         ),
         "cuxfilter": RAPIDSRepository(
@@ -120,7 +128,11 @@ all_metadata.versions["24.08"] = RAPIDSVersion(
             packages={
                 "libraft": RAPIDSPackage(),
                 "libraft-headers": RAPIDSPackage(),
+                "libraft-headers-only": RAPIDSPackage(is_conda_only=True),
+                "libraft-static": RAPIDSPackage(is_conda_only=True),
                 "pylibraft": RAPIDSPackage(),
+                "raft-ann-bench": RAPIDSPackage(is_conda_only=True),
+                "raft-ann-bench-cpu": RAPIDSPackage(is_conda_only=True),
                 "raft-dask": RAPIDSPackage(),
             }
         ),
@@ -150,6 +162,7 @@ all_metadata.versions["24.08"] = RAPIDSVersion(
         "wholegraph": RAPIDSRepository(
             packages={
                 "pylibwholegraph": RAPIDSPackage(),
+                "libwholegraph": RAPIDSPackage(is_conda_only=True),
             }
         ),
     }
@@ -162,7 +175,7 @@ all_metadata.versions["24.10"].repositories["cudf"].packages["pylibcudf"] = (
 all_metadata.versions["24.10"].repositories["cuvs"] = RAPIDSRepository(
     packages={
         "cuvs": RAPIDSPackage(),
-        "libcuvs": RAPIDSPackage(),
+        "libcuvs": RAPIDSPackage(is_conda_only=True),
     }
 )
 
@@ -174,6 +187,8 @@ del all_metadata.versions["24.12"].repositories["cugraph"].packages["cugraph-equ
 del all_metadata.versions["24.12"].repositories["cugraph"].packages["cugraph-pyg"]
 del all_metadata.versions["24.12"].repositories["cugraph"].packages["nx-cugraph"]
 del all_metadata.versions["24.12"].repositories["wholegraph"]
+del all_metadata.versions["24.12"].repositories["raft"].packages["raft-ann-bench"]
+del all_metadata.versions["24.12"].repositories["raft"].packages["raft-ann-bench-cpu"]
 # fmt: on
 
 all_metadata.versions["24.12"].repositories["cugraph-gnn"] = RAPIDSRepository(
@@ -181,6 +196,7 @@ all_metadata.versions["24.12"].repositories["cugraph-gnn"] = RAPIDSRepository(
         "cugraph-dgl": RAPIDSPackage(),
         "cugraph-pyg": RAPIDSPackage(),
         "pylibwholegraph": RAPIDSPackage(),
+        "libwholegraph": RAPIDSPackage(is_conda_only=True),
     }
 )
 
@@ -188,6 +204,16 @@ all_metadata.versions["24.12"].repositories["nx-cugraph"] = RAPIDSRepository(
     packages={
         "nx-cugraph": RAPIDSPackage(),
     }
+)
+
+all_metadata.versions["24.12"].repositories["cuvs"].packages["cuvs-bench"] = (
+    RAPIDSPackage(is_conda_only=True)
+)
+all_metadata.versions["24.12"].repositories["cuvs"].packages["cuvs-bench-cpu"] = (
+    RAPIDSPackage(is_conda_only=True)
+)
+all_metadata.versions["24.12"].repositories["cuvs"].packages["libcuvs-static"] = (
+    RAPIDSPackage(is_conda_only=True)
 )
 
 all_metadata.versions["25.02"] = deepcopy(all_metadata.versions["24.12"])

--- a/src/rapids_metadata/__init__.py
+++ b/src/rapids_metadata/__init__.py
@@ -37,7 +37,7 @@ all_metadata.versions["24.08"] = RAPIDSVersion(
         "cucim": RAPIDSRepository(
             packages={
                 "cucim": RAPIDSPackage(),
-                "libcucim": RAPIDSPackage(is_conda_only=True),
+                "libcucim": RAPIDSPackage(has_wheel_package=False),
             }
         ),
         "cudf": RAPIDSRepository(
@@ -45,10 +45,10 @@ all_metadata.versions["24.08"] = RAPIDSVersion(
                 "cudf": RAPIDSPackage(),
                 "cudf-polars": RAPIDSPackage(),
                 "cudf_kafka": RAPIDSPackage(),
-                "custreamz": RAPIDSPackage(is_conda_only=True),
+                "custreamz": RAPIDSPackage(has_wheel_package=False),
                 "dask-cudf": RAPIDSPackage(),
                 "libcudf": RAPIDSPackage(),
-                "libcudf_kafka": RAPIDSPackage(is_conda_only=True),
+                "libcudf_kafka": RAPIDSPackage(has_wheel_package=False),
             }
         ),
         "cugraph": RAPIDSRepository(
@@ -58,11 +58,11 @@ all_metadata.versions["24.08"] = RAPIDSVersion(
                 "cugraph-equivariant": RAPIDSPackage(),
                 "cugraph-pyg": RAPIDSPackage(),
                 "cugraph-service-client": RAPIDSPackage(
-                    has_cuda_suffix=False, is_conda_only=True
+                    has_cuda_suffix=False, has_wheel_package=False
                 ),
-                "cugraph-service-server": RAPIDSPackage(is_conda_only=True),
-                "libcugraph": RAPIDSPackage(is_conda_only=True),
-                "libcugraph_etl": RAPIDSPackage(is_conda_only=True),
+                "cugraph-service-server": RAPIDSPackage(has_wheel_package=False),
+                "libcugraph": RAPIDSPackage(has_wheel_package=False),
+                "libcugraph_etl": RAPIDSPackage(has_wheel_package=False),
                 "nx-cugraph": RAPIDSPackage(),
                 "pylibcugraph": RAPIDSPackage(),
             }
@@ -76,9 +76,9 @@ all_metadata.versions["24.08"] = RAPIDSVersion(
         "cuml": RAPIDSRepository(
             packages={
                 "cuml": RAPIDSPackage(),
-                "cuml-cpu": RAPIDSPackage(is_conda_only=True),
-                "libcuml": RAPIDSPackage(is_conda_only=True),
-                "libcuml-tests": RAPIDSPackage(is_conda_only=True),
+                "cuml-cpu": RAPIDSPackage(has_wheel_package=False),
+                "libcuml": RAPIDSPackage(has_wheel_package=False),
+                "libcuml-tests": RAPIDSPackage(has_wheel_package=False),
             }
         ),
         "cumlprims_mg": RAPIDSRepository(
@@ -95,7 +95,7 @@ all_metadata.versions["24.08"] = RAPIDSVersion(
             packages={
                 "cuspatial": RAPIDSPackage(),
                 "libcuspatial": RAPIDSPackage(),
-                "libcuspatial-tests": RAPIDSPackage(is_conda_only=True),
+                "libcuspatial-tests": RAPIDSPackage(has_wheel_package=False),
             }
         ),
         "cuxfilter": RAPIDSRepository(
@@ -128,11 +128,11 @@ all_metadata.versions["24.08"] = RAPIDSVersion(
             packages={
                 "libraft": RAPIDSPackage(),
                 "libraft-headers": RAPIDSPackage(),
-                "libraft-headers-only": RAPIDSPackage(is_conda_only=True),
-                "libraft-static": RAPIDSPackage(is_conda_only=True),
+                "libraft-headers-only": RAPIDSPackage(has_wheel_package=False),
+                "libraft-static": RAPIDSPackage(has_wheel_package=False),
                 "pylibraft": RAPIDSPackage(),
-                "raft-ann-bench": RAPIDSPackage(is_conda_only=True),
-                "raft-ann-bench-cpu": RAPIDSPackage(is_conda_only=True),
+                "raft-ann-bench": RAPIDSPackage(has_wheel_package=False),
+                "raft-ann-bench-cpu": RAPIDSPackage(has_wheel_package=False),
                 "raft-dask": RAPIDSPackage(),
             }
         ),
@@ -162,7 +162,7 @@ all_metadata.versions["24.08"] = RAPIDSVersion(
         "wholegraph": RAPIDSRepository(
             packages={
                 "pylibwholegraph": RAPIDSPackage(),
-                "libwholegraph": RAPIDSPackage(is_conda_only=True),
+                "libwholegraph": RAPIDSPackage(has_wheel_package=False),
             }
         ),
     }
@@ -175,7 +175,7 @@ all_metadata.versions["24.10"].repositories["cudf"].packages["pylibcudf"] = (
 all_metadata.versions["24.10"].repositories["cuvs"] = RAPIDSRepository(
     packages={
         "cuvs": RAPIDSPackage(),
-        "libcuvs": RAPIDSPackage(is_conda_only=True),
+        "libcuvs": RAPIDSPackage(has_wheel_package=False),
     }
 )
 
@@ -196,7 +196,7 @@ all_metadata.versions["24.12"].repositories["cugraph-gnn"] = RAPIDSRepository(
         "cugraph-dgl": RAPIDSPackage(),
         "cugraph-pyg": RAPIDSPackage(),
         "pylibwholegraph": RAPIDSPackage(),
-        "libwholegraph": RAPIDSPackage(is_conda_only=True),
+        "libwholegraph": RAPIDSPackage(has_wheel_package=False),
     }
 )
 
@@ -207,13 +207,13 @@ all_metadata.versions["24.12"].repositories["nx-cugraph"] = RAPIDSRepository(
 )
 
 all_metadata.versions["24.12"].repositories["cuvs"].packages["cuvs-bench"] = (
-    RAPIDSPackage(is_conda_only=True)
+    RAPIDSPackage(has_wheel_package=False)
 )
 all_metadata.versions["24.12"].repositories["cuvs"].packages["cuvs-bench-cpu"] = (
-    RAPIDSPackage(is_conda_only=True)
+    RAPIDSPackage(has_wheel_package=False)
 )
 all_metadata.versions["24.12"].repositories["cuvs"].packages["libcuvs-static"] = (
-    RAPIDSPackage(is_conda_only=True)
+    RAPIDSPackage(has_wheel_package=False)
 )
 
 all_metadata.versions["25.02"] = deepcopy(all_metadata.versions["24.12"])

--- a/src/rapids_metadata/metadata.py
+++ b/src/rapids_metadata/metadata.py
@@ -45,6 +45,11 @@ class RAPIDSPackage:
         description="""Whether or not the package has a CUDA suffix.""",
     )
 
+    is_conda_only: bool = Field(
+        default=False,
+        description="""Whether or not the package exists only as a conda package.""",
+    )
+
 
 @dataclass
 class RAPIDSRepository:

--- a/src/rapids_metadata/metadata.py
+++ b/src/rapids_metadata/metadata.py
@@ -45,9 +45,14 @@ class RAPIDSPackage:
         description="""Whether or not the package has a CUDA suffix.""",
     )
 
-    is_conda_only: bool = Field(
-        default=False,
-        description="""Whether or not the package exists only as a conda package.""",
+    has_conda_package: bool = Field(
+        default=True,
+        description="""Whether or not the package exists as a conda package.""",
+    )
+
+    has_wheel_package: bool = Field(
+        default=True,
+        description="""Whether or not the package exists as a wheel package.""",
     )
 
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -43,9 +43,33 @@ def set_cwd(cwd: os.PathLike) -> Generator:
 @pytest.mark.parametrize(
     ["unencoded", "encoded"],
     [
-        (RAPIDSPackage(), {"publishes_prereleases": True, "has_cuda_suffix": True, "has_conda_package": True, "has_wheel_package": True}),
-        (RAPIDSPackage(has_conda_package=False), {"publishes_prereleases": True, "has_cuda_suffix": True, "has_conda_package": False, "has_wheel_package": True}),
-        (RAPIDSPackage(has_wheel_package=False), {"publishes_prereleases": True, "has_cuda_suffix": True, "has_conda_package": True, "has_wheel_package": False}),
+        (
+            RAPIDSPackage(),
+            {
+                "publishes_prereleases": True,
+                "has_cuda_suffix": True,
+                "has_conda_package": True,
+                "has_wheel_package": True,
+            },
+        ),
+        (
+            RAPIDSPackage(has_conda_package=False),
+            {
+                "publishes_prereleases": True,
+                "has_cuda_suffix": True,
+                "has_conda_package": False,
+                "has_wheel_package": True,
+            },
+        ),
+        (
+            RAPIDSPackage(has_wheel_package=False),
+            {
+                "publishes_prereleases": True,
+                "has_cuda_suffix": True,
+                "has_conda_package": True,
+                "has_wheel_package": False,
+            },
+        ),
         (
             RAPIDSRepository(
                 packages={
@@ -61,13 +85,13 @@ def set_cwd(cwd: os.PathLike) -> Generator:
                         "publishes_prereleases": True,
                         "has_cuda_suffix": True,
                         "has_conda_package": True,
-                        "has_wheel_package": True
+                        "has_wheel_package": True,
                     },
                     "package2": {
                         "publishes_prereleases": False,
                         "has_cuda_suffix": False,
                         "has_conda_package": True,
-                        "has_wheel_package": True
+                        "has_wheel_package": True,
                     },
                 },
             },
@@ -99,7 +123,7 @@ def set_cwd(cwd: os.PathLike) -> Generator:
                                 "publishes_prereleases": True,
                                 "has_cuda_suffix": True,
                                 "has_conda_package": True,
-                                "has_wheel_package": True
+                                "has_wheel_package": True,
                             },
                         },
                     },
@@ -109,7 +133,7 @@ def set_cwd(cwd: os.PathLike) -> Generator:
                                 "publishes_prereleases": True,
                                 "has_cuda_suffix": True,
                                 "has_conda_package": True,
-                                "has_wheel_package": True
+                                "has_wheel_package": True,
                             },
                         },
                     },

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -43,7 +43,9 @@ def set_cwd(cwd: os.PathLike) -> Generator:
 @pytest.mark.parametrize(
     ["unencoded", "encoded"],
     [
-        (RAPIDSPackage(), {"publishes_prereleases": True, "has_cuda_suffix": True}),
+        (RAPIDSPackage(), {"publishes_prereleases": True, "has_cuda_suffix": True, "has_conda_package": True, "has_wheel_package": True}),
+        (RAPIDSPackage(has_conda_package=False), {"publishes_prereleases": True, "has_cuda_suffix": True, "has_conda_package": False, "has_wheel_package": True}),
+        (RAPIDSPackage(has_wheel_package=False), {"publishes_prereleases": True, "has_cuda_suffix": True, "has_conda_package": True, "has_wheel_package": False}),
         (
             RAPIDSRepository(
                 packages={
@@ -58,10 +60,14 @@ def set_cwd(cwd: os.PathLike) -> Generator:
                     "package1": {
                         "publishes_prereleases": True,
                         "has_cuda_suffix": True,
+                        "has_conda_package": True,
+                        "has_wheel_package": True
                     },
                     "package2": {
                         "publishes_prereleases": False,
                         "has_cuda_suffix": False,
+                        "has_conda_package": True,
+                        "has_wheel_package": True
                     },
                 },
             },
@@ -92,6 +98,8 @@ def set_cwd(cwd: os.PathLike) -> Generator:
                             "package": {
                                 "publishes_prereleases": True,
                                 "has_cuda_suffix": True,
+                                "has_conda_package": True,
+                                "has_wheel_package": True
                             },
                         },
                     },
@@ -100,6 +108,8 @@ def set_cwd(cwd: os.PathLike) -> Generator:
                             "proprietary-package": {
                                 "publishes_prereleases": True,
                                 "has_cuda_suffix": True,
+                                "has_conda_package": True,
+                                "has_wheel_package": True
                             },
                         },
                     },
@@ -151,7 +161,9 @@ def test_metadata_encoder(unencoded, encoded):
             '"repo1":{'
             '"packages":{'
             '"package":{'
+            '"has_conda_package":true,'
             '"has_cuda_suffix":true,'
+            '"has_wheel_package":true,'
             '"publishes_prereleases":true'
             "}"
             "}"
@@ -171,7 +183,9 @@ def test_metadata_encoder(unencoded, encoded):
             '"repo2":{'
             '"packages":{'
             '"package":{'
+            '"has_conda_package":true,'
             '"has_cuda_suffix":true,'
+            '"has_wheel_package":true,'
             '"publishes_prereleases":true'
             "}"
             "}"
@@ -191,7 +205,9 @@ def test_metadata_encoder(unencoded, encoded):
             '"repo2":{'
             '"packages":{'
             '"package":{'
+            '"has_conda_package":true,'
             '"has_cuda_suffix":true,'
+            '"has_wheel_package":true,'
             '"publishes_prereleases":true'
             "}"
             "}"
@@ -211,7 +227,9 @@ def test_metadata_encoder(unencoded, encoded):
             '"repo1":{'
             '"packages":{'
             '"package":{'
+            '"has_conda_package":true,'
             '"has_cuda_suffix":true,'
+            '"has_wheel_package":true,'
             '"publishes_prereleases":true'
             "}"
             "}"
@@ -223,7 +241,9 @@ def test_metadata_encoder(unencoded, encoded):
             '"repo2":{'
             '"packages":{'
             '"package":{'
+            '"has_conda_package":true,'
             '"has_cuda_suffix":true,'
+            '"has_wheel_package":true,'
             '"publishes_prereleases":true'
             "}"
             "}"
@@ -245,7 +265,9 @@ def test_metadata_encoder(unencoded, encoded):
                         "repo1": {
                           "packages": {
                             "package": {
+                              "has_conda_package": true,
                               "has_cuda_suffix": true,
+                              "has_wheel_package": true,
                               "publishes_prereleases": true
                             }
                           }


### PR DESCRIPTION
Add `has_conda_package` and `has_wheel_package` fields which default to `true`, and update for 24.12.