### PR TITLE
add cugraph-docs

### DIFF
--- a/rapids-metadata.json
+++ b/rapids-metadata.json
@@ -1392,6 +1392,9 @@
             }
           }
         },
+        "cugraph-docs": {
+          "packages": {}
+        },
         "cugraph-gnn": {
           "packages": {
             "cugraph-dgl": {

--- a/src/rapids_metadata/__init__.py
+++ b/src/rapids_metadata/__init__.py
@@ -218,5 +218,5 @@ all_metadata.versions["24.12"].repositories["cuvs"].packages["libcuvs-static"] =
 
 all_metadata.versions["25.02"] = deepcopy(all_metadata.versions["24.12"])
 all_metadata.versions["25.02"].repositories["cugraph-docs"] = RAPIDSRepository(
-    packages={}
+    packages=dict()
 )

--- a/src/rapids_metadata/__init__.py
+++ b/src/rapids_metadata/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -217,3 +217,6 @@ all_metadata.versions["24.12"].repositories["cuvs"].packages["libcuvs-static"] =
 )
 
 all_metadata.versions["25.02"] = deepcopy(all_metadata.versions["24.12"])
+all_metadata.versions["25.02"].repositories["cugraph-docs"] = RAPIDSRepository(
+    packages={}
+)


### PR DESCRIPTION
Adds the https://github.com/rapidsai/cugraph-docs repo.

`cugraph-docs` does not produce any packages... it's just used for building cuGraph docs. But it does follow RAPIDS calendar-versioning scheme and should get the usual release updates (like having `ci/release/update-version.sh` run on it), so I think it belongs here.