### PR TITLE
WIP: remove cugraph-ops

### DIFF
--- a/rapids-metadata.json
+++ b/rapids-metadata.json
@@ -1423,22 +1423,6 @@
             }
           }
         },
-        "cugraph-ops": {
-          "packages": {
-            "libcugraphops": {
-              "has_conda_package": true,
-              "has_cuda_suffix": true,
-              "has_wheel_package": true,
-              "publishes_prereleases": true
-            },
-            "pylibcugraphops": {
-              "has_conda_package": true,
-              "has_cuda_suffix": true,
-              "has_wheel_package": true,
-              "publishes_prereleases": true
-            }
-          }
-        },
         "cuml": {
           "packages": {
             "cuml": {

--- a/src/rapids_metadata/__init__.py
+++ b/src/rapids_metadata/__init__.py
@@ -220,3 +220,4 @@ all_metadata.versions["25.02"] = deepcopy(all_metadata.versions["24.12"])
 all_metadata.versions["25.02"].repositories["cugraph-docs"] = RAPIDSRepository(
     packages=dict()
 )
+del all_metadata.versions["25.02"].repositories["cugraph-ops"]


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-infra/issues/155 (private issue)

Stops triggering nightly builds and tests of `cugraph-ops`.

## Notes for Reviewers

This should not be merged until the following are complete:

* [x] https://github.com/rapidsai/cugraph-gnn/pull/99