### PR TITLE
Updates for 25.02

### DIFF
--- a/rapids-metadata.json
+++ b/rapids-metadata.json
@@ -285,7 +285,7 @@
             "libraft": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
-              "has_wheel_package": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "libraft-headers": {
@@ -715,7 +715,7 @@
             "libraft": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
-              "has_wheel_package": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "libraft-headers": {
@@ -1177,7 +1177,7 @@
             "libraft": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
-              "has_wheel_package": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "libraft-headers": {
@@ -1416,22 +1416,6 @@
               "publishes_prereleases": true
             },
             "pylibwholegraph": {
-              "has_conda_package": true,
-              "has_cuda_suffix": true,
-              "has_wheel_package": true,
-              "publishes_prereleases": true
-            }
-          }
-        },
-        "cugraph-ops": {
-          "packages": {
-            "libcugraphops": {
-              "has_conda_package": true,
-              "has_cuda_suffix": true,
-              "has_wheel_package": true,
-              "publishes_prereleases": true
-            },
-            "pylibcugraphops": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,

--- a/src/rapids_metadata/__init__.py
+++ b/src/rapids_metadata/__init__.py
@@ -126,7 +126,7 @@ all_metadata.versions["24.08"] = RAPIDSVersion(
         ),
         "raft": RAPIDSRepository(
             packages={
-                "libraft": RAPIDSPackage(),
+                "libraft": RAPIDSPackage(has_wheel_package=False),
                 "libraft-headers": RAPIDSPackage(),
                 "libraft-headers-only": RAPIDSPackage(has_wheel_package=False),
                 "libraft-static": RAPIDSPackage(has_wheel_package=False),
@@ -219,4 +219,8 @@ all_metadata.versions["24.12"].repositories["cuvs"].packages["libcuvs-static"] =
 all_metadata.versions["25.02"] = deepcopy(all_metadata.versions["24.12"])
 all_metadata.versions["25.02"].repositories["cugraph-docs"] = RAPIDSRepository(
     packages=dict()
+)
+del all_metadata.versions["25.02"].repositories["cugraph-ops"]
+all_metadata.versions["25.02"].repositories["raft"].packages["libraft"] = RAPIDSPackage(
+    has_wheel_package=True
 )


### PR DESCRIPTION
Updates for RAPIDS `25.02`

1. Drops `cugraph-ops`
2. Retroactively updates `libraft` to have no wheels until `25.02`
