### PR TITLE
Include runtime dependencies in Conda package

### DIFF
--- a/conda/recipes/rapids-metadata/meta.yaml
+++ b/conda/recipes/rapids-metadata/meta.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 
 {% set pyproject_data = load_file_data("pyproject.toml") %}
 {% set version = pyproject_data["project"]["version"] %}
@@ -22,6 +22,11 @@ requirements:
     - python >=3.9
     - conda-verify
     {% for r in pyproject_data["build-system"]["requires"] %}
+    - {{ r }}
+    {% endfor %}
+  run:
+    - python >=3.9
+    {% for r in pyproject_data["project"]["dependencies"] %}
     - {{ r }}
     {% endfor %}
 


### PR DESCRIPTION
Just as is done with host requirements, pull in run requirements from `pyproject.toml`'s metadata.