### PR TITLE
add new C++ wheels: libcuvs, libcugraph, libcuml

### DIFF
--- a/rapids-metadata.json
+++ b/rapids-metadata.json
@@ -1440,7 +1440,7 @@
             "libcuml": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
-              "has_wheel_package": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libcuml-tests": {
@@ -1861,7 +1861,7 @@
             "libcuml": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
-              "has_wheel_package": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libcuml-tests": {

--- a/rapids-metadata.json
+++ b/rapids-metadata.json
@@ -1375,7 +1375,7 @@
             "libcugraph": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
-              "has_wheel_package": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libcugraph_etl": {
@@ -1440,7 +1440,7 @@
             "libcuml": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
-              "has_wheel_package": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libcuml-tests": {
@@ -1516,7 +1516,7 @@
             "libcuvs": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
-              "has_wheel_package": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libcuvs-static": {

--- a/rapids-metadata.json
+++ b/rapids-metadata.json
@@ -1440,7 +1440,7 @@
             "libcuml": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
-              "has_wheel_package": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "libcuml-tests": {
@@ -1796,7 +1796,7 @@
             "libcugraph": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
-              "has_wheel_package": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libcugraph_etl": {
@@ -1937,7 +1937,7 @@
             "libcuvs": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
-              "has_wheel_package": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "libcuvs-static": {

--- a/src/rapids_metadata/__init__.py
+++ b/src/rapids_metadata/__init__.py
@@ -224,6 +224,9 @@ del all_metadata.versions["25.02"].repositories["cugraph-ops"]
 all_metadata.versions["25.02"].repositories["cugraph"].packages["libcugraph"] = (
     RAPIDSPackage(has_wheel_package=True)
 )
+all_metadata.versions["25.02"].repositories["cuml"].packages["libcuml"] = RAPIDSPackage(
+    has_wheel_package=True
+)
 all_metadata.versions["25.02"].repositories["cuvs"].packages["libcuvs"] = RAPIDSPackage(
     has_wheel_package=True
 )

--- a/src/rapids_metadata/__init__.py
+++ b/src/rapids_metadata/__init__.py
@@ -221,6 +221,15 @@ all_metadata.versions["25.02"].repositories["cugraph-docs"] = RAPIDSRepository(
     packages=dict()
 )
 del all_metadata.versions["25.02"].repositories["cugraph-ops"]
+all_metadata.versions["25.02"].repositories["cugraph"].packages["libcugraph"] = (
+    RAPIDSPackage(has_wheel_package=True)
+)
+all_metadata.versions["25.02"].repositories["cuml"].packages["libcuml"] = RAPIDSPackage(
+    has_wheel_package=True
+)
+all_metadata.versions["25.02"].repositories["cuvs"].packages["libcuvs"] = RAPIDSPackage(
+    has_wheel_package=True
+)
 all_metadata.versions["25.02"].repositories["raft"].packages["libraft"] = RAPIDSPackage(
     has_wheel_package=True
 )

--- a/src/rapids_metadata/__init__.py
+++ b/src/rapids_metadata/__init__.py
@@ -224,9 +224,6 @@ del all_metadata.versions["25.02"].repositories["cugraph-ops"]
 all_metadata.versions["25.02"].repositories["cugraph"].packages["libcugraph"] = (
     RAPIDSPackage(has_wheel_package=True)
 )
-all_metadata.versions["25.02"].repositories["cuml"].packages["libcuml"] = RAPIDSPackage(
-    has_wheel_package=True
-)
 all_metadata.versions["25.02"].repositories["cuvs"].packages["libcuvs"] = RAPIDSPackage(
     has_wheel_package=True
 )


### PR DESCRIPTION
Proposes updating the metadata here to account for new wheels added in the 25.02 release cycle.

This shouldn't be merged until all of these are:

* [x] `libcugraph` (https://github.com/rapidsai/cugraph/pull/4804)
* [x] `libcuml`  (https://github.com/rapidsai/cuml/pull/6199 )
* [x] `libcuvs` (https://github.com/rapidsai/cuvs/pull/594)