### PR TITLE
Use SPDX license identifier in pyproject.toml

### DIFF
--- a/conda/recipes/rapids-metadata/meta.yaml
+++ b/conda/recipes/rapids-metadata/meta.yaml
@@ -10,7 +10,7 @@
 
 # Load `about` metadata
 {% set home = pyproject_data["project"]["urls"]["Homepage"] %}
-{% set license = pyproject_data["project"]["license"]["text"] %}
+{% set license = pyproject_data["project"]["license"] %}
 {% set license_files = pyproject_data["tool"]["setuptools"]["license-files"] %}
 {% set summary = pyproject_data["project"]["description"] %}
 {% set dev_url = pyproject_data["project"]["urls"]["Source"] %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ authors = [
 ]
 description = "metadata for structure of RAPIDS projects"
 readme = "README.md"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
This uses an SPDX identifier for the project `license` field in `pyproject.toml`.

xref: https://github.com/rapidsai/build-planning/issues/152
