### PR TITLE
remove conda-verify dependency

### DIFF
--- a/conda/recipes/rapids-metadata/meta.yaml
+++ b/conda/recipes/rapids-metadata/meta.yaml
@@ -33,7 +33,6 @@ requirements:
   host:
     - pip
     - python {{ python_version }}
-    - conda-verify
     {% for r in requirements_host %}
     - {{ r }}
     {% endfor %}


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/150

Fixes #43

Proposes removing `host:` dependency on `conda-verify`. See the discussion in https://github.com/rapidsai/rapids-metadata/issues/43 for background.