### PR TITLE
Moving wheel builds to specified location and uploading build artifacts to Github

### DIFF
--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -36,6 +36,9 @@ jobs:
       script: "ci/build_wheel.sh"
       # Select only the build with the minimum Python version and the maximum CUDA version
       matrix_filter: '[map(select(.ARCH == "amd64")) | min_by((.PY_VER | split(".") | map(tonumber)), (.CUDA_VER | split(".") | map(-tonumber)))]'
+      wheel-name: rapids-metadata
+      package-type: python
+      append-cuda-suffix: false
   publish-wheels:
     needs:
       - build-wheel

--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -22,7 +22,7 @@ jobs:
         run: "./ci/check_style.sh"
   build-conda:
     needs: check-style
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-24.08
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-25.06
     with:
       build_type: ${{ inputs.build_type }}
       script: "ci/build_python.sh"
@@ -30,7 +30,7 @@ jobs:
       matrix_filter: '[map(select(.ARCH == "amd64")) | min_by((.PY_VER | split(".") | map(tonumber)), (.CUDA_VER | split(".") | map(-tonumber)))]'
   build-wheel:
     needs: check-style
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-24.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-25.06
     with:
       build_type: ${{ inputs.build_type }}
       script: "ci/build_wheel.sh"
@@ -43,7 +43,7 @@ jobs:
     needs:
       - build-wheel
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-24.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-25.06
     with:
       build_type: ${{ inputs.build_type }}
       package-name: rapids-metadata
@@ -53,7 +53,7 @@ jobs:
     needs:
       - build-conda
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@branch-24.08
+    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@branch-25.06
     with:
       build_type: ${{ inputs.build_type }}
     if: ${{ inputs.publish }}

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -3,15 +3,11 @@
 
 set -euo pipefail
 
-wheel_dir="${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"
-
-mkdir -p "${wheel_dir}"
-
-python -m pip wheel . -w "${wheel_dir}" -vv --no-deps --disable-pip-version-check
+python -m pip wheel . -w "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}" -vv --no-deps --disable-pip-version-check
 
 # Run tests
-WHL_FILE=$(ls "${wheel_dir}"/*.whl)
+WHL_FILE=$(ls "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"/*.whl)
 python -m pip install "${WHL_FILE}[test]"
 python -m pytest -v tests/
 
-RAPIDS_PY_WHEEL_NAME="rapids-metadata" rapids-upload-wheels-to-s3 python "${wheel_dir}"
+RAPIDS_PY_WHEEL_NAME="rapids-metadata" rapids-upload-wheels-to-s3 python "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -3,11 +3,15 @@
 
 set -euo pipefail
 
-python -m pip wheel . -w dist -vv --no-deps --disable-pip-version-check
+wheel_dir="${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"
+
+mkdir -p "${wheel_dir}"
+
+python -m pip wheel . -w "${wheel_dir}" -vv --no-deps --disable-pip-version-check
 
 # Run tests
-WHL_FILE=$(ls dist/*.whl)
+WHL_FILE=$(ls "${wheel_dir}"/*.whl)
 python -m pip install "${WHL_FILE}[test]"
 python -m pytest -v tests/
 
-RAPIDS_PY_WHEEL_NAME="rapids-metadata" rapids-upload-wheels-to-s3 dist
+RAPIDS_PY_WHEEL_NAME="rapids-metadata" rapids-upload-wheels-to-s3 python "${wheel_dir}"

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 
 set -euo pipefail
 


### PR DESCRIPTION
This work is towards moving build artifacts from `downloads.rapids.ai` to Github Artifact Store (see https://github.com/rapidsai/ops/issues/2982)

As part of these changes, all wheel builds need to be in a specified temporary directory indicated by the environment variable `RAPIDS_WHEEL_BLD_OUTPUT_DIR` set on the `ci-wheel` Docker image used for building wheels. This lets us upload all wheel artifacts seamlessly to Github Artifacts. 