### PR TITLE
Add rapidsai/rapids-multi-gpu to 25.06

### DIFF
--- a/rapids-metadata.json
+++ b/rapids-metadata.json
@@ -2505,6 +2505,22 @@
             }
           }
         },
+        "rapidsmpf": {
+          "packages": {
+            "librapidsmpf": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "rapidsmpf": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            }
+          }
+        },
         "rmm": {
           "packages": {
             "librmm": {

--- a/src/rapids_metadata/__init__.py
+++ b/src/rapids_metadata/__init__.py
@@ -240,3 +240,9 @@ all_metadata.versions["25.04"].repositories["rapids-logger"] = RAPIDSRepository(
 )
 
 all_metadata.versions["25.06"] = deepcopy(all_metadata.versions["25.04"])
+all_metadata.versions["25.06"].repositories["rapidsmpf"] = RAPIDSRepository(
+    packages={
+        "rapidsmpf": RAPIDSPackage(),
+        "librapidsmpf": RAPIDSPackage(),
+    }
+)


### PR DESCRIPTION
Adds new `rapidsmpf` and `librapidsmpf` packages to 25.06.

`rapidsmpf` is used as repository name because the repository will be renamed to `rapidsmpf`.