### PR TITLE
updated wheel-name to package-name in CI workflows

### DIFF
--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -36,7 +36,7 @@ jobs:
       script: "ci/build_wheel.sh"
       # Select only the build with the minimum Python version and the maximum CUDA version
       matrix_filter: '[map(select(.ARCH == "amd64")) | min_by((.PY_VER | split(".") | map(tonumber)), (.CUDA_VER | split(".") | map(-tonumber)))]'
-      wheel-name: rapids-metadata
+      package-name: rapids-metadata
       package-type: python
       append-cuda-suffix: false
   publish-wheels:


### PR DESCRIPTION
This work is towards moving build artifacts from `downloads.rapids.ai` to Github Artifact Store (see https://github.com/rapidsai/ops/issues/2982)

Updates CI workflows to follow `package-name` convention between wheel build and wheel publish jobs. 