### PR TITLE
refactor: add libwholegraph wheel for 25.06

### DIFF
--- a/rapids-metadata.json
+++ b/rapids-metadata.json
@@ -395,7 +395,7 @@
             "libwholegraph": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
-              "has_wheel_package": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "pylibwholegraph": {

--- a/rapids-metadata.json
+++ b/rapids-metadata.json
@@ -395,7 +395,7 @@
             "libwholegraph": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
-              "has_wheel_package": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "pylibwholegraph": {
@@ -2264,7 +2264,7 @@
             "libwholegraph": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
-              "has_wheel_package": false,
+              "has_wheel_package": true,
               "publishes_prereleases": true
             },
             "pylibwholegraph": {

--- a/src/rapids_metadata/__init__.py
+++ b/src/rapids_metadata/__init__.py
@@ -240,3 +240,6 @@ all_metadata.versions["25.04"].repositories["rapids-logger"] = RAPIDSRepository(
 )
 
 all_metadata.versions["25.06"] = deepcopy(all_metadata.versions["25.04"])
+all_metadata.versions["25.06"].repositories["cugraph-gnn"].packages["libwholegraph"] = RAPIDSPackage(
+    has_wheel_package=True
+)

--- a/src/rapids_metadata/__init__.py
+++ b/src/rapids_metadata/__init__.py
@@ -21,7 +21,6 @@ from .metadata import (
     RAPIDSVersion,
 )
 
-
 __all__ = ["all_metadata"]
 
 
@@ -242,6 +241,7 @@ all_metadata.versions["25.04"].repositories["rapids-logger"] = RAPIDSRepository(
 all_metadata.versions["25.06"] = deepcopy(all_metadata.versions["25.04"])
 all_metadata.versions["25.06"].repositories["cugraph-gnn"].packages["libwholegraph"] = (
     RAPIDSPackage(has_wheel_package=True)
+)
 all_metadata.versions["25.06"].repositories["rapidsmpf"] = RAPIDSRepository(
     packages={
         "rapidsmpf": RAPIDSPackage(),

--- a/src/rapids_metadata/__init__.py
+++ b/src/rapids_metadata/__init__.py
@@ -240,6 +240,6 @@ all_metadata.versions["25.04"].repositories["rapids-logger"] = RAPIDSRepository(
 )
 
 all_metadata.versions["25.06"] = deepcopy(all_metadata.versions["25.04"])
-all_metadata.versions["25.06"].repositories["cugraph-gnn"].packages["libwholegraph"] = RAPIDSPackage(
-    has_wheel_package=True
+all_metadata.versions["25.06"].repositories["cugraph-gnn"].packages["libwholegraph"] = (
+    RAPIDSPackage(has_wheel_package=True)
 )


### PR DESCRIPTION
`libwholegraph` wheels were added in rapidsai/cugraph-gnn#182
xref: rapidsai/rapids-wheels-planning#59

Updating the metadata here to reflect that.
