### PR TITLE
stop uploading to downloads.rapids.ai, add shellcheck

### DIFF
--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -22,7 +22,7 @@ jobs:
         run: "./ci/check_style.sh"
   build-conda:
     needs: check-style
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-25.06
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-25.08
     with:
       build_type: ${{ inputs.build_type }}
       script: "ci/build_python.sh"
@@ -30,7 +30,7 @@ jobs:
       matrix_filter: '[map(select(.ARCH == "amd64")) | min_by((.PY_VER | split(".") | map(tonumber)), (.CUDA_VER | split(".") | map(-tonumber)))]'
   build-wheel:
     needs: check-style
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-25.06
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-25.08
     with:
       build_type: ${{ inputs.build_type }}
       script: "ci/build_wheel.sh"
@@ -43,7 +43,7 @@ jobs:
     needs:
       - build-wheel
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-25.06
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-25.08
     with:
       build_type: ${{ inputs.build_type }}
       package-name: rapids-metadata
@@ -53,7 +53,7 @@ jobs:
     needs:
       - build-conda
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@branch-25.06
+    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@branch-25.08
     with:
       build_type: ${{ inputs.build_type }}
     if: ${{ inputs.publish }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,11 @@ repos:
       - id: ruff
         args: ["--fix"]
       - id: ruff-format
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+        args: ["--severity=warning"]
   - repo: https://github.com/rapidsai/pre-commit-hooks
     rev: v0.4.0
     hooks:

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -4,5 +4,3 @@
 set -euo pipefail
 
 rapids-conda-retry build conda/recipes/rapids-metadata
-
-rapids-upload-conda-to-s3 python

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -9,5 +9,3 @@ python -m pip wheel . -w "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}" -vv --no-deps --disabl
 WHL_FILE=$(ls "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"/*.whl)
 python -m pip install "${WHL_FILE}[test]"
 python -m pytest -v tests/
-
-RAPIDS_PY_WHEEL_NAME="rapids-metadata" rapids-upload-wheels-to-s3 python "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/181

* removes all uploads of conda packages and wheels to `downloads.rapids.ai`
* updates to `branch-25.08` of `shared-workflows`, to pull in https://github.com/rapidsai/shared-workflows/pull/364

Contributes to https://github.com/rapidsai/build-planning/issues/135

* adds `shellcheck` checks to `pre-commit` configuration

## Notes for Reviewers

### How I identified changes

Looked for uses of the relevant `gha-tools` tools, as well as documentation about `downloads.rapids.ai`, being on the NVIDIA VPN, using S3, etc. like this:

```shell
git grep -i -E 's3|upload|downloads\.rapids|vpn'
```

### How I tested this

See "How I tested this" on https://github.com/rapidsai/shared-workflows/pull/364