### PR TITLE
add rapids-cli

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,16 +15,16 @@ repos:
               rapids-metadata[.]json$|
               schemas/rapids-metadata-v[0-9]+[.]json$
   - repo: https://github.com/rapidsai/dependency-file-generator
-    rev: v1.17.0
+    rev: v1.18.1
     hooks:
       - id: rapids-dependency-file-generator
         args: ["--clean"]
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.1
     hooks:
       - id: codespell
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.5
+    rev: v0.11.12
     hooks:
       - id: ruff
         args: ["--fix"]
@@ -35,12 +35,12 @@ repos:
       - id: shellcheck
         args: ["--severity=warning"]
   - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: v0.4.0
+    rev: v0.6.0
     hooks:
       - id: verify-copyright
         args: [--fix, --main-branch=main]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.14.1'
+    rev: 'v1.16.0'
     hooks:
       - id: mypy
         args: [

--- a/rapids-metadata.json
+++ b/rapids-metadata.json
@@ -2457,6 +2457,16 @@
             }
           }
         },
+        "rapids-cli": {
+          "packages": {
+            "rapids-cli": {
+              "has_conda_package": true,
+              "has_cuda_suffix": false,
+              "has_wheel_package": true,
+              "publishes_prereleases": false
+            }
+          }
+        },
         "rapids-dask-dependency": {
           "packages": {
             "rapids-dask-dependency": {
@@ -2857,6 +2867,16 @@
               "has_cuda_suffix": true,
               "has_wheel_package": true,
               "publishes_prereleases": true
+            }
+          }
+        },
+        "rapids-cli": {
+          "packages": {
+            "rapids-cli": {
+              "has_conda_package": true,
+              "has_cuda_suffix": false,
+              "has_wheel_package": true,
+              "publishes_prereleases": false
             }
           }
         },

--- a/src/rapids_metadata/__init__.py
+++ b/src/rapids_metadata/__init__.py
@@ -242,6 +242,14 @@ all_metadata.versions["25.06"] = deepcopy(all_metadata.versions["25.04"])
 all_metadata.versions["25.06"].repositories["cugraph-gnn"].packages["libwholegraph"] = (
     RAPIDSPackage(has_wheel_package=True)
 )
+all_metadata.versions["25.06"].repositories["rapids-cli"] = RAPIDSRepository(
+    packages={
+        "rapids-cli": RAPIDSPackage(
+            publishes_prereleases=False,
+            has_cuda_suffix=False,
+        ),
+    }
+)
 all_metadata.versions["25.06"].repositories["rapidsmpf"] = RAPIDSRepository(
     packages={
         "rapidsmpf": RAPIDSPackage(),


### PR DESCRIPTION
Adds https://github.com/rapidsai/rapids-cli, which we recently started publishing packages for:

* https://github.com/rapidsai/rapids-cli/issues/89
* https://github.com/rapidsai/rapids-cli/issues/90

Similar to `pynvjitlink` (which is already included in this repo), this project does ad hoc releases not aligned to the RAPIDS release schedule, and uses a 3-part version number (e.g., the latest release was `0.1.2`).

Adding this to 25.06 because it was included in the 25.06 `rapidsai/docker` images: https://github.com/rapidsai/docker/pull/764

While I'm touching this repo, also updated all the `pre-commit` hooks with `pre-commit autoupdate`.