### PR TITLE
Add `version_file` argument to `get_rapids_version()`

### DIFF
--- a/src/rapids_metadata/metadata.py
+++ b/src/rapids_metadata/metadata.py
@@ -118,11 +118,13 @@ class RAPIDSMetadata:
     )
 
     def get_current_version(
-        self, directory: Union[str, PathLike[str]]
+        self,
+        directory: Union[str, PathLike[str]],
+        version_file: Union[str, PathLike[str]] = "VERSION",
     ) -> RAPIDSVersion:
         from packaging.version import Version
 
-        current_version = get_rapids_version(directory)
+        current_version = get_rapids_version(directory, version_file)
         try:
             return self.versions[current_version]
         except KeyError:

--- a/src/rapids_metadata/rapids_version.py
+++ b/src/rapids_metadata/rapids_version.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,12 +20,15 @@ from typing import Union
 __all__ = ["get_rapids_version"]
 
 
-def get_rapids_version(directory: Union[str, PathLike[str]]) -> str:
+def get_rapids_version(
+    directory: Union[str, PathLike[str]],
+    version_file: Union[str, PathLike[str]] = "VERSION",
+) -> str:
     from packaging.version import InvalidVersion, Version
 
     while not os.path.samefile(directory, os.path.dirname(directory)):
         try:
-            with open(os.path.join(directory, "VERSION")) as f:
+            with open(os.path.join(directory, version_file)) as f:
                 version = Version(f.read())
         except (FileNotFoundError, InvalidVersion):
             directory = os.path.dirname(directory)


### PR DESCRIPTION
This will allow us to better support projects like ucxx, which use a different versioning scheme but still store their RAPIDS version in a separate file.