### PR TITLE
drop pynvjitlink from RAPIDS 25.10

### DIFF
--- a/rapids-metadata.json
+++ b/rapids-metadata.json
@@ -3209,16 +3209,6 @@
             }
           }
         },
-        "pynvjitlink": {
-          "packages": {
-            "pynvjitlink": {
-              "has_conda_package": true,
-              "has_cuda_suffix": true,
-              "has_wheel_package": true,
-              "publishes_prereleases": true
-            }
-          }
-        },
         "raft": {
           "packages": {
             "libraft": {

--- a/src/rapids_metadata/__init__.py
+++ b/src/rapids_metadata/__init__.py
@@ -265,5 +265,6 @@ del all_metadata.versions["25.08"].repositories["cugraph-gnn"].packages["cugraph
 del all_metadata.versions["25.08"].repositories["_nvidia"].packages["cubinlinker"]
 
 all_metadata.versions["25.10"] = deepcopy(all_metadata.versions["25.08"])
-del all_metadata.versions["25.10"].repositories["ucx-py"]
 del all_metadata.versions["25.10"].repositories["cuproj"]
+del all_metadata.versions["25.10"].repositories["pynvjitlink"]
+del all_metadata.versions["25.10"].repositories["ucx-py"]


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/210

`pynvjitlink` is set to be archived, and we won't publish new packages for it in RAPIDS 25.10. This proposes removing it from that release.