### PR TITLE
add nvforest, 26.06 packages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     hooks:
       - id: codespell
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.14
+    rev: v0.15.4
     hooks:
       - id: ruff
         args: ["--fix"]
@@ -35,7 +35,7 @@ repos:
       - id: shellcheck
         args: ["--severity=warning"]
   - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: v1.3.3
+    rev: v1.4.3
     hooks:
       - id: verify-copyright
         args: [--fix, --main-branch=main]

--- a/rapids-metadata.json
+++ b/rapids-metadata.json
@@ -4367,6 +4367,373 @@
           }
         }
       }
+    },
+    "26.06": {
+      "repositories": {
+        "cucim": {
+          "packages": {
+            "cucim": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libcucim": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            }
+          }
+        },
+        "cudf": {
+          "packages": {
+            "cudf": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "cudf-polars": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "cudf_kafka": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
+            "custreamz": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
+            "dask-cudf": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libcudf": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libcudf_kafka": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
+            "pylibcudf": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            }
+          }
+        },
+        "cugraph": {
+          "packages": {
+            "cugraph": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libcugraph": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libcugraph_etl": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
+            "pylibcugraph": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            }
+          }
+        },
+        "cugraph-docs": {
+          "packages": {}
+        },
+        "cugraph-gnn": {
+          "packages": {
+            "cugraph-pyg": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libwholegraph": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "pylibwholegraph": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            }
+          }
+        },
+        "cuml": {
+          "packages": {
+            "cuml": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libcuml": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libcuml-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            }
+          }
+        },
+        "cuvs": {
+          "packages": {
+            "cuvs": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "cuvs-bench": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
+            "cuvs-bench-cpu": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
+            "libcuvs": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libcuvs-static": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            }
+          }
+        },
+        "cuxfilter": {
+          "packages": {
+            "cuxfilter": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            }
+          }
+        },
+        "dask-cuda": {
+          "packages": {
+            "dask-cuda": {
+              "has_conda_package": true,
+              "has_cuda_suffix": false,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            }
+          }
+        },
+        "kvikio": {
+          "packages": {
+            "kvikio": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libkvikio": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            }
+          }
+        },
+        "nvforest": {
+          "packages": {
+            "libnvforest": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "nvforest": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            }
+          }
+        },
+        "nx-cugraph": {
+          "packages": {
+            "nx-cugraph": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            }
+          }
+        },
+        "raft": {
+          "packages": {
+            "libraft": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libraft-headers": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
+            "libraft-headers-only": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
+            "libraft-static": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
+            "pylibraft": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "raft-dask": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            }
+          }
+        },
+        "rapids-cli": {
+          "packages": {
+            "rapids-cli": {
+              "has_conda_package": true,
+              "has_cuda_suffix": false,
+              "has_wheel_package": true,
+              "publishes_prereleases": false
+            }
+          }
+        },
+        "rapids-dask-dependency": {
+          "packages": {
+            "rapids-dask-dependency": {
+              "has_conda_package": true,
+              "has_cuda_suffix": false,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            }
+          }
+        },
+        "rapids-logger": {
+          "packages": {
+            "rapids-logger": {
+              "has_conda_package": true,
+              "has_cuda_suffix": false,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            }
+          }
+        },
+        "rapidsmpf": {
+          "packages": {
+            "librapidsmpf": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "rapidsmpf": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            }
+          }
+        },
+        "rmm": {
+          "packages": {
+            "librmm": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "rmm": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            }
+          }
+        },
+        "ucxx": {
+          "packages": {
+            "distributed-ucxx": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libucxx": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "ucxx": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/rapids-metadata.json
+++ b/rapids-metadata.json
@@ -4216,6 +4216,22 @@
             }
           }
         },
+        "nvforest": {
+          "packages": {
+            "libnvforest": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "nvforest": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            }
+          }
+        },
         "nx-cugraph": {
           "packages": {
             "nx-cugraph": {

--- a/src/rapids_metadata/__init__.py
+++ b/src/rapids_metadata/__init__.py
@@ -296,3 +296,5 @@ all_metadata.versions["26.04"].repositories["nvforest"] = RAPIDSRepository(
         ),
     }
 )
+
+all_metadata.versions["26.06"] = deepcopy(all_metadata.versions["26.04"])

--- a/src/rapids_metadata/__init__.py
+++ b/src/rapids_metadata/__init__.py
@@ -280,3 +280,19 @@ all_metadata.versions["26.02"] = deepcopy(all_metadata.versions["25.12"])
 del all_metadata.versions["26.02"].repositories["cumlprims_mg"]
 
 all_metadata.versions["26.04"] = deepcopy(all_metadata.versions["26.02"])
+all_metadata.versions["26.04"].repositories["nvforest"] = RAPIDSRepository(
+    packages={
+        "libnvforest": RAPIDSPackage(
+            publishes_prereleases=True,
+            has_cuda_suffix=True,
+            has_conda_package=True,
+            has_wheel_package=True,
+        ),
+        "nvforest": RAPIDSPackage(
+            publishes_prereleases=True,
+            has_cuda_suffix=True,
+            has_conda_package=True,
+            has_wheel_package=True,
+        ),
+    }
+)


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/nvforest/issues/13

Adds `nvforest`.

Also updates all `pre-commit` hooks with `pre-commit autoupdate` (might as well, to take advantage of the CI run 🤷🏻 )