### PR TITLE
fix(ci): resolve all zizmor findings and add zizmor pre-commit checks

### DIFF
--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -1,14 +1,12 @@
 name: build
-
 on:
   push:
     branches:
       - "main"
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
-
+permissions: {}
 jobs:
   run-checks:
     uses: ./.github/workflows/checks-and-builds.yaml

--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -13,4 +13,8 @@ jobs:
     with:
       build_type: branch
       publish: false
-    secrets: inherit
+    secrets:
+      CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}
+      RAPIDSAI_PYPI_TOKEN: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}
+      CONDA_RAPIDSAI_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_NIGHTLY_TOKEN }}
+      CONDA_RAPIDSAI_TOKEN: ${{ secrets.CONDA_RAPIDSAI_TOKEN }}

--- a/.github/workflows/build-tag.yaml
+++ b/.github/workflows/build-tag.yaml
@@ -1,14 +1,12 @@
 name: build
-
 on:
   push:
     tags:
       - "v*.*.*"
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
-
+permissions: {}
 jobs:
   run-checks:
     uses: ./.github/workflows/checks-and-builds.yaml

--- a/.github/workflows/build-tag.yaml
+++ b/.github/workflows/build-tag.yaml
@@ -13,4 +13,8 @@ jobs:
     with:
       build_type: branch
       publish: true
-    secrets: inherit
+    secrets:
+      CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}
+      RAPIDSAI_PYPI_TOKEN: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}
+      CONDA_RAPIDSAI_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_NIGHTLY_TOKEN }}
+      CONDA_RAPIDSAI_TOKEN: ${{ secrets.CONDA_RAPIDSAI_TOKEN }}

--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -1,5 +1,4 @@
 name: checks
-
 on:
   workflow_call:
     inputs:
@@ -7,7 +6,7 @@ on:
         type: string
       publish:
         type: boolean
-
+permissions: {}
 jobs:
   check-style:
     runs-on: ubuntu-latest
@@ -28,6 +27,12 @@ jobs:
       script: "ci/build_python.sh"
       # Select only the build with the minimum Python version and the maximum CUDA version
       matrix_filter: '[map(select(.ARCH == "amd64")) | min_by((.PY_VER | split(".") | map(tonumber)), (.CUDA_VER | split(".") | map(-tonumber)))]'
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
   build-wheel:
     needs: check-style
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
@@ -39,6 +44,12 @@ jobs:
       package-name: rapids-metadata
       package-type: python
       append-cuda-suffix: false
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
   publish-wheels:
     needs:
       - build-wheel
@@ -49,6 +60,12 @@ jobs:
       package-name: rapids-metadata
       publish_to_pypi: true
     if: ${{ inputs.publish }}
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
   publish-conda:
     needs:
       - build-conda
@@ -57,3 +74,9 @@ jobs:
     with:
       build_type: ${{ inputs.build_type }}
     if: ${{ inputs.publish }}
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read

--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -15,7 +15,7 @@ jobs:
       image: rapidsai/ci-conda:latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
       - name: Check style

--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -6,6 +6,15 @@ on:
         type: string
       publish:
         type: boolean
+    secrets:
+      CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN:
+        required: true
+      RAPIDSAI_PYPI_TOKEN:
+        required: true
+      CONDA_RAPIDSAI_NIGHTLY_TOKEN:
+        required: true
+      CONDA_RAPIDSAI_TOKEN:
+        required: true
 permissions: {}
 jobs:
   check-style:
@@ -53,7 +62,9 @@ jobs:
   publish-wheels:
     needs:
       - build-wheel
-    secrets: inherit
+    secrets:
+      CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}
+      RAPIDSAI_PYPI_TOKEN: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}
     uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@main
     with:
       build_type: ${{ inputs.build_type }}
@@ -69,7 +80,9 @@ jobs:
   publish-conda:
     needs:
       - build-conda
-    secrets: inherit
+    secrets:
+      CONDA_RAPIDSAI_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_NIGHTLY_TOKEN }}
+      CONDA_RAPIDSAI_TOKEN: ${{ secrets.CONDA_RAPIDSAI_TOKEN }}
     uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@main
     with:
       build_type: ${{ inputs.build_type }}

--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -20,12 +20,13 @@ jobs:
   check-style:
     runs-on: ubuntu-latest
     container:
-      image: rapidsai/ci-conda:latest
+      image: rapidsai/ci-conda:latest # zizmor: ignore[unpinned-images]
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Check style
         run: "./ci/check_style.sh"
   build-conda:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,14 +1,12 @@
 name: pr
-
 on:
   push:
     branches:
       - "pull-request/[0-9]+"
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
+permissions: {}
 jobs:
   run-checks:
     uses: ./.github/workflows/checks-and-builds.yaml

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,4 +13,8 @@ jobs:
     with:
       build_type: pull-request
       publish: false
-    secrets: inherit
+    secrets:
+      CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}
+      RAPIDSAI_PYPI_TOKEN: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}
+      CONDA_RAPIDSAI_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_NIGHTLY_TOKEN }}
+      CONDA_RAPIDSAI_TOKEN: ${{ secrets.CONDA_RAPIDSAI_TOKEN }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,9 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # We require SHA-pinning for all workflows and actions _except_ for those from
+        # rapidsai/shared-workflows and rapidsai/shared-actions
+        "rapidsai/shared-workflows/*": any
+        "rapidsai/shared-actions/*": any
+        "*": hash-pin


### PR DESCRIPTION

Similar to upstream changes in `shared-workflows`, this PR cleans up and annotates all of the workflows and adds the `zizmor` linter to make sure changes are checked.

Part of https://github.com/rapidsai/build-planning/issues/275