### PR TITLE
add cuvs-lucene, enforce zizmor checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,16 +15,16 @@ repos:
               rapids-metadata[.]json$|
               schemas/rapids-metadata-v[0-9]+[.]json$
   - repo: https://github.com/rapidsai/dependency-file-generator
-    rev: v1.20.2
+    rev: v1.20.3
     hooks:
       - id: rapids-dependency-file-generator
         args: ["--clean", "--warn-all", "--strict"]
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.2
     hooks:
       - id: codespell
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.4
+    rev: v0.15.15
     hooks:
       - id: ruff-check
         args: ["--fix"]
@@ -41,7 +41,7 @@ repos:
         args: [--fix, --main-branch=main]
       - id: verify-pyproject-license
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.19.1'
+    rev: 'v2.1.0'
     hooks:
       - id: mypy
         args: [
@@ -52,6 +52,10 @@ repos:
         additional_dependencies:
           - packaging
           - pydantic
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.25.2
+    hooks:
+      - id: zizmor
   - repo: local
     hooks:
       - id: generate-json

--- a/rapids-metadata.json
+++ b/rapids-metadata.json
@@ -3117,6 +3117,16 @@
             }
           }
         },
+        "cuvs-lucene": {
+          "packages": {
+            "cuvs-lucene": {
+              "has_conda_package": false,
+              "has_cuda_suffix": false,
+              "has_wheel_package": false,
+              "publishes_prereleases": false
+            }
+          }
+        },
         "cuxfilter": {
           "packages": {
             "cuxfilter": {
@@ -3478,6 +3488,16 @@
             }
           }
         },
+        "cuvs-lucene": {
+          "packages": {
+            "cuvs-lucene": {
+              "has_conda_package": false,
+              "has_cuda_suffix": false,
+              "has_wheel_package": false,
+              "publishes_prereleases": false
+            }
+          }
+        },
         "cuxfilter": {
           "packages": {
             "cuxfilter": {
@@ -3829,6 +3849,16 @@
             }
           }
         },
+        "cuvs-lucene": {
+          "packages": {
+            "cuvs-lucene": {
+              "has_conda_package": false,
+              "has_cuda_suffix": false,
+              "has_wheel_package": false,
+              "publishes_prereleases": false
+            }
+          }
+        },
         "cuxfilter": {
           "packages": {
             "cuxfilter": {
@@ -4177,6 +4207,16 @@
               "has_cuda_suffix": true,
               "has_wheel_package": false,
               "publishes_prereleases": true
+            }
+          }
+        },
+        "cuvs-lucene": {
+          "packages": {
+            "cuvs-lucene": {
+              "has_conda_package": false,
+              "has_cuda_suffix": false,
+              "has_wheel_package": false,
+              "publishes_prereleases": false
             }
           }
         },
@@ -4547,6 +4587,16 @@
             }
           }
         },
+        "cuvs-lucene": {
+          "packages": {
+            "cuvs-lucene": {
+              "has_conda_package": false,
+              "has_cuda_suffix": false,
+              "has_wheel_package": false,
+              "publishes_prereleases": false
+            }
+          }
+        },
         "cuxfilter": {
           "packages": {
             "cuxfilter": {
@@ -4911,6 +4961,16 @@
               "has_cuda_suffix": true,
               "has_wheel_package": false,
               "publishes_prereleases": true
+            }
+          }
+        },
+        "cuvs-lucene": {
+          "packages": {
+            "cuvs-lucene": {
+              "has_conda_package": false,
+              "has_cuda_suffix": false,
+              "has_wheel_package": false,
+              "publishes_prereleases": false
             }
           }
         },

--- a/src/rapids_metadata/__init__.py
+++ b/src/rapids_metadata/__init__.py
@@ -264,6 +264,17 @@ all_metadata.versions["25.10"] = deepcopy(all_metadata.versions["25.08"])
 del all_metadata.versions["25.10"].repositories["pynvjitlink"]
 del all_metadata.versions["25.10"].repositories["ucx-py"]
 
+all_metadata.versions["25.10"].repositories["cuvs-lucene"] = RAPIDSRepository(
+    packages={
+        "cuvs-lucene": RAPIDSPackage(
+            publishes_prereleases=False,
+            has_cuda_suffix=False,
+            has_conda_package=False,
+            has_wheel_package=False,
+        ),
+    }
+)
+
 all_metadata.versions["25.12"] = deepcopy(all_metadata.versions["25.10"])
 del (
     all_metadata.versions["25.12"]


### PR DESCRIPTION
Cleaning up a few things missed in previous releases:

* adds `cuvs-lucene` ([which has been published alongside RAPIDS since 25.10](https://github.com/rapidsai/cuvs-lucene/tags))
* enforces `zizmor` checks (missed in #75)