### PR TITLE
drop cuxfilter, update all pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     hooks:
       - id: codespell
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.15
+    rev: v0.15.16
     hooks:
       - id: ruff-check
         args: ["--fix"]
@@ -35,7 +35,7 @@ repos:
       - id: shellcheck
         args: ["--severity=warning"]
   - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: v1.4.3
+    rev: v1.5.0
     hooks:
       - id: verify-copyright
         args: [--fix, --main-branch=main]

--- a/rapids-metadata.json
+++ b/rapids-metadata.json
@@ -4974,16 +4974,6 @@
             }
           }
         },
-        "cuxfilter": {
-          "packages": {
-            "cuxfilter": {
-              "has_conda_package": true,
-              "has_cuda_suffix": true,
-              "has_wheel_package": true,
-              "publishes_prereleases": true
-            }
-          }
-        },
         "dask-cuda": {
           "packages": {
             "dask-cuda": {

--- a/src/rapids_metadata/__init__.py
+++ b/src/rapids_metadata/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, NVIDIA CORPORATION.
+# Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -311,3 +311,4 @@ all_metadata.versions["26.04"].repositories["nvforest"] = RAPIDSRepository(
 all_metadata.versions["26.06"] = deepcopy(all_metadata.versions["26.04"])
 
 all_metadata.versions["26.08"] = deepcopy(all_metadata.versions["26.06"])
+del all_metadata.versions["26.08"].repositories["cuxfilter"]


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/291

Drops `cuxfilter`, which is set to be archived (see linked issue for details).

While we're doing a CI run and review anyway, bumped all the `pre-commit` hooks with `pre-commit autoupdate` too.