### PR TITLE
Added 26.10 metadata, new cudf packages

### DIFF
--- a/rapids-metadata.json
+++ b/rapids-metadata.json
@@ -4115,6 +4115,12 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "libcugraph-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "libcugraph_etl": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
@@ -4144,6 +4150,12 @@
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libwholegraph-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "pylibwholegraph": {
@@ -4207,6 +4219,12 @@
               "has_cuda_suffix": true,
               "has_wheel_package": false,
               "publishes_prereleases": true
+            },
+            "libcuvs-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
             }
           }
         },
@@ -4253,6 +4271,12 @@
               "has_cuda_suffix": true,
               "has_wheel_package": true,
               "publishes_prereleases": true
+            },
+            "libkvikio-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
             }
           }
         },
@@ -4262,6 +4286,12 @@
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libnvforest-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "nvforest": {
@@ -4303,6 +4333,12 @@
               "publishes_prereleases": true
             },
             "libraft-static": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
+            "libraft-tests": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": false,
@@ -4360,6 +4396,12 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "librapidsmpf-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "rapidsmpf": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
@@ -4374,6 +4416,12 @@
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "librmm-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "rmm": {
@@ -4464,6 +4512,12 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "libcudf-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "libcudf_kafka": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
@@ -4490,6 +4544,12 @@
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libcugraph-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "libcugraph_etl": {
@@ -4521,6 +4581,12 @@
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libwholegraph-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "pylibwholegraph": {
@@ -4584,6 +4650,12 @@
               "has_cuda_suffix": true,
               "has_wheel_package": false,
               "publishes_prereleases": true
+            },
+            "libcuvs-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
             }
           }
         },
@@ -4630,6 +4702,12 @@
               "has_cuda_suffix": true,
               "has_wheel_package": true,
               "publishes_prereleases": true
+            },
+            "libkvikio-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
             }
           }
         },
@@ -4639,6 +4717,12 @@
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libnvforest-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "nvforest": {
@@ -4680,6 +4764,12 @@
               "publishes_prereleases": true
             },
             "libraft-static": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
+            "libraft-tests": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": false,
@@ -4737,6 +4827,12 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "librapidsmpf-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "rapidsmpf": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
@@ -4751,6 +4847,12 @@
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "librmm-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "rmm": {
@@ -4775,10 +4877,22 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "libucxx-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "ucxx": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "ucxx-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             }
           }
@@ -4853,6 +4967,18 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "libcudf-streaming-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
+            "libcudf-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "libcudf_kafka": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
@@ -4879,6 +5005,12 @@
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libcugraph-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "libcugraph_etl": {
@@ -4910,6 +5042,12 @@
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libwholegraph-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "pylibwholegraph": {
@@ -4973,6 +5111,12 @@
               "has_cuda_suffix": true,
               "has_wheel_package": false,
               "publishes_prereleases": true
+            },
+            "libcuvs-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
             }
           }
         },
@@ -5009,6 +5153,12 @@
               "has_cuda_suffix": true,
               "has_wheel_package": true,
               "publishes_prereleases": true
+            },
+            "libkvikio-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
             }
           }
         },
@@ -5018,6 +5168,12 @@
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libnvforest-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "nvforest": {
@@ -5059,6 +5215,12 @@
               "publishes_prereleases": true
             },
             "libraft-static": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
+            "libraft-tests": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": false,
@@ -5116,6 +5278,12 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "librapidsmpf-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "rapidsmpf": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
@@ -5130,6 +5298,12 @@
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "librmm-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "rmm": {
@@ -5154,10 +5328,22 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "libucxx-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "ucxx": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "ucxx-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             }
           }
@@ -5232,6 +5418,18 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "libcudf-streaming-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
+            "libcudf-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "libcudf_kafka": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
@@ -5258,6 +5456,12 @@
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libcugraph-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "libcugraph_etl": {
@@ -5289,6 +5493,12 @@
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libwholegraph-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "pylibwholegraph": {
@@ -5352,6 +5562,12 @@
               "has_cuda_suffix": true,
               "has_wheel_package": false,
               "publishes_prereleases": true
+            },
+            "libcuvs-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
             }
           }
         },
@@ -5388,6 +5604,12 @@
               "has_cuda_suffix": true,
               "has_wheel_package": true,
               "publishes_prereleases": true
+            },
+            "libkvikio-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
             }
           }
         },
@@ -5397,6 +5619,12 @@
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libnvforest-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "nvforest": {
@@ -5438,6 +5666,12 @@
               "publishes_prereleases": true
             },
             "libraft-static": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
+            "libraft-tests": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": false,
@@ -5495,6 +5729,12 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "librapidsmpf-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "rapidsmpf": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
@@ -5509,6 +5749,12 @@
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "librmm-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "rmm": {
@@ -5533,10 +5779,22 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "libucxx-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "ucxx": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "ucxx-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             }
           }

--- a/rapids-metadata.json
+++ b/rapids-metadata.json
@@ -4817,6 +4817,12 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "cudf-streaming": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
             "cudf_kafka": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
@@ -4841,6 +4847,12 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "libcudf-streaming": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
             "libcudf_kafka": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
@@ -4848,18 +4860,6 @@
               "publishes_prereleases": true
             },
             "pylibcudf": {
-              "has_conda_package": true,
-              "has_cuda_suffix": true,
-              "has_wheel_package": true,
-              "publishes_prereleases": true
-            },
-            "libcudf-streaming": {
-              "has_conda_package": true,
-              "has_cuda_suffix": true,
-              "has_wheel_package": true,
-              "publishes_prereleases": true
-            },
-            "cudf-streaming": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
@@ -5196,6 +5196,12 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "cudf-streaming": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
             "cudf_kafka": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
@@ -5220,6 +5226,12 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "libcudf-streaming": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
             "libcudf_kafka": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
@@ -5227,18 +5239,6 @@
               "publishes_prereleases": true
             },
             "pylibcudf": {
-              "has_conda_package": true,
-              "has_cuda_suffix": true,
-              "has_wheel_package": true,
-              "publishes_prereleases": true
-            },
-            "libcudf-streaming": {
-              "has_conda_package": true,
-              "has_cuda_suffix": true,
-              "has_wheel_package": true,
-              "publishes_prereleases": true
-            },
-            "cudf-streaming": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,

--- a/rapids-metadata.json
+++ b/rapids-metadata.json
@@ -4852,6 +4852,397 @@
               "has_cuda_suffix": true,
               "has_wheel_package": true,
               "publishes_prereleases": true
+            },
+            "libcudf-streaming": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "cudf-streaming": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            }
+          }
+        },
+        "cugraph": {
+          "packages": {
+            "cugraph": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libcugraph": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libcugraph_etl": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
+            "pylibcugraph": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            }
+          }
+        },
+        "cugraph-docs": {
+          "packages": {}
+        },
+        "cugraph-gnn": {
+          "packages": {
+            "cugraph-pyg": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libwholegraph": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "pylibwholegraph": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            }
+          }
+        },
+        "cuml": {
+          "packages": {
+            "cuml": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libcuml": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libcuml-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            }
+          }
+        },
+        "cuvs": {
+          "packages": {
+            "cuvs": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "cuvs-bench": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
+            "cuvs-bench-cpu": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
+            "libcuvs": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libcuvs-static": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            }
+          }
+        },
+        "cuvs-lucene": {
+          "packages": {
+            "cuvs-lucene": {
+              "has_conda_package": false,
+              "has_cuda_suffix": false,
+              "has_wheel_package": false,
+              "publishes_prereleases": false
+            }
+          }
+        },
+        "dask-cuda": {
+          "packages": {
+            "dask-cuda": {
+              "has_conda_package": true,
+              "has_cuda_suffix": false,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            }
+          }
+        },
+        "kvikio": {
+          "packages": {
+            "kvikio": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libkvikio": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            }
+          }
+        },
+        "nvforest": {
+          "packages": {
+            "libnvforest": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "nvforest": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            }
+          }
+        },
+        "nx-cugraph": {
+          "packages": {
+            "nx-cugraph": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            }
+          }
+        },
+        "raft": {
+          "packages": {
+            "libraft": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libraft-headers": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
+            "libraft-headers-only": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
+            "libraft-static": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
+            "pylibraft": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "raft-dask": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            }
+          }
+        },
+        "rapids-cli": {
+          "packages": {
+            "rapids-cli": {
+              "has_conda_package": true,
+              "has_cuda_suffix": false,
+              "has_wheel_package": true,
+              "publishes_prereleases": false
+            }
+          }
+        },
+        "rapids-dask-dependency": {
+          "packages": {
+            "rapids-dask-dependency": {
+              "has_conda_package": true,
+              "has_cuda_suffix": false,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            }
+          }
+        },
+        "rapids-logger": {
+          "packages": {
+            "rapids-logger": {
+              "has_conda_package": true,
+              "has_cuda_suffix": false,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            }
+          }
+        },
+        "rapidsmpf": {
+          "packages": {
+            "librapidsmpf": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "rapidsmpf": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            }
+          }
+        },
+        "rmm": {
+          "packages": {
+            "librmm": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "rmm": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            }
+          }
+        },
+        "ucxx": {
+          "packages": {
+            "distributed-ucxx": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libucxx": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "ucxx": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            }
+          }
+        }
+      }
+    },
+    "26.10": {
+      "repositories": {
+        "cucim": {
+          "packages": {
+            "cucim": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libcucim": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            }
+          }
+        },
+        "cudf": {
+          "packages": {
+            "cudf": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "cudf-polars": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "cudf_kafka": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
+            "custreamz": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
+            "dask-cudf": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libcudf": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libcudf_kafka": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
+            "pylibcudf": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libcudf-streaming": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "cudf-streaming": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": true,
+              "publishes_prereleases": true
             }
           }
         },

--- a/rapids-metadata.json
+++ b/rapids-metadata.json
@@ -1326,6 +1326,12 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "libcudf-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "libcudf_kafka": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
@@ -1366,6 +1372,12 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "libcugraph-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "libcugraph_etl": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
@@ -1398,6 +1410,12 @@
               "publishes_prereleases": true
             },
             "libwholegraph": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
+            "libwholegraph-tests": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": false,
@@ -1508,6 +1526,12 @@
               "has_cuda_suffix": true,
               "has_wheel_package": false,
               "publishes_prereleases": true
+            },
+            "libcuvs-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
             }
           }
         },
@@ -1543,6 +1567,12 @@
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libkvikio-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             }
           }
@@ -1603,6 +1633,12 @@
               "has_wheel_package": false,
               "publishes_prereleases": true
             },
+            "libraft-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "pylibraft": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
@@ -1635,6 +1671,12 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "librmm-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "rmm": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
@@ -1665,6 +1707,12 @@
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libucxx-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "ucxx": {
@@ -1743,6 +1791,12 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "libcudf-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "libcudf_kafka": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
@@ -1783,6 +1837,12 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "libcugraph-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "libcugraph_etl": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
@@ -1815,6 +1875,12 @@
               "publishes_prereleases": true
             },
             "libwholegraph": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
+            "libwholegraph-tests": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": false,
@@ -1925,6 +1991,12 @@
               "has_cuda_suffix": true,
               "has_wheel_package": false,
               "publishes_prereleases": true
+            },
+            "libcuvs-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
             }
           }
         },
@@ -1960,6 +2032,12 @@
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libkvikio-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             }
           }
@@ -2020,6 +2098,12 @@
               "has_wheel_package": false,
               "publishes_prereleases": true
             },
+            "libraft-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "pylibraft": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
@@ -2062,6 +2146,12 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "librmm-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "rmm": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
@@ -2094,10 +2184,22 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "libucxx-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "ucxx": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "ucxx-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             }
           }
@@ -2170,6 +2272,12 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "libcudf-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "libcudf_kafka": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
@@ -2210,6 +2318,12 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "libcugraph-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "libcugraph_etl": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
@@ -2245,6 +2359,12 @@
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libwholegraph-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "pylibwholegraph": {
@@ -2318,6 +2438,12 @@
               "has_cuda_suffix": true,
               "has_wheel_package": false,
               "publishes_prereleases": true
+            },
+            "libcuvs-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
             }
           }
         },
@@ -2353,6 +2479,12 @@
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libkvikio-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             }
           }
@@ -2413,6 +2545,12 @@
               "has_wheel_package": false,
               "publishes_prereleases": true
             },
+            "libraft-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "pylibraft": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
@@ -2465,6 +2603,12 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "librapidsmpf-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "rapidsmpf": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
@@ -2479,6 +2623,12 @@
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "librmm-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "rmm": {
@@ -2513,10 +2663,22 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "libucxx-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "ucxx": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "ucxx-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             }
           }
@@ -2579,6 +2741,12 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "libcudf-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "libcudf_kafka": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
@@ -2619,6 +2787,12 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "libcugraph-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "libcugraph_etl": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
@@ -2648,6 +2822,12 @@
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libwholegraph-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "pylibwholegraph": {
@@ -2721,6 +2901,12 @@
               "has_cuda_suffix": true,
               "has_wheel_package": false,
               "publishes_prereleases": true
+            },
+            "libcuvs-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
             }
           }
         },
@@ -2756,6 +2942,12 @@
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libkvikio-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             }
           }
@@ -2801,6 +2993,12 @@
               "publishes_prereleases": true
             },
             "libraft-static": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
+            "libraft-tests": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": false,
@@ -2858,6 +3056,12 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "librapidsmpf-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "rapidsmpf": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
@@ -2872,6 +3076,12 @@
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "librmm-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "rmm": {
@@ -2906,10 +3116,22 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "libucxx-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "ucxx": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "ucxx-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             }
           }
@@ -2972,6 +3194,12 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "libcudf-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "libcudf_kafka": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
@@ -3012,6 +3240,12 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "libcugraph-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "libcugraph_etl": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
@@ -3041,6 +3275,12 @@
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libwholegraph-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "pylibwholegraph": {
@@ -3114,6 +3354,12 @@
               "has_cuda_suffix": true,
               "has_wheel_package": false,
               "publishes_prereleases": true
+            },
+            "libcuvs-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
             }
           }
         },
@@ -3160,6 +3406,12 @@
               "has_cuda_suffix": true,
               "has_wheel_package": true,
               "publishes_prereleases": true
+            },
+            "libkvikio-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
             }
           }
         },
@@ -3194,6 +3446,12 @@
               "publishes_prereleases": true
             },
             "libraft-static": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
+            "libraft-tests": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": false,
@@ -3251,6 +3509,12 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "librapidsmpf-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "rapidsmpf": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
@@ -3265,6 +3529,12 @@
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "librmm-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "rmm": {
@@ -3289,10 +3559,22 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "libucxx-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "ucxx": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "ucxx-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             }
           }
@@ -3355,6 +3637,12 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "libcudf-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "libcudf_kafka": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
@@ -3381,6 +3669,12 @@
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libcugraph-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "libcugraph_etl": {
@@ -3412,6 +3706,12 @@
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libwholegraph-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "pylibwholegraph": {
@@ -3485,6 +3785,12 @@
               "has_cuda_suffix": true,
               "has_wheel_package": false,
               "publishes_prereleases": true
+            },
+            "libcuvs-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
             }
           }
         },
@@ -3531,6 +3837,12 @@
               "has_cuda_suffix": true,
               "has_wheel_package": true,
               "publishes_prereleases": true
+            },
+            "libkvikio-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
             }
           }
         },
@@ -3565,6 +3877,12 @@
               "publishes_prereleases": true
             },
             "libraft-static": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
+            "libraft-tests": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": false,
@@ -3622,6 +3940,12 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "librapidsmpf-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "rapidsmpf": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
@@ -3636,6 +3960,12 @@
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "librmm-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "rmm": {
@@ -3660,10 +3990,22 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "libucxx-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "ucxx": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "ucxx-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             }
           }
@@ -3726,6 +4068,12 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "libcudf-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "libcudf_kafka": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
@@ -3752,6 +4100,12 @@
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libcugraph-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "libcugraph_etl": {
@@ -3783,6 +4137,12 @@
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libwholegraph-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "pylibwholegraph": {
@@ -3846,6 +4206,12 @@
               "has_cuda_suffix": true,
               "has_wheel_package": false,
               "publishes_prereleases": true
+            },
+            "libcuvs-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
             }
           }
         },
@@ -3892,6 +4258,12 @@
               "has_cuda_suffix": true,
               "has_wheel_package": true,
               "publishes_prereleases": true
+            },
+            "libkvikio-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
             }
           }
         },
@@ -3926,6 +4298,12 @@
               "publishes_prereleases": true
             },
             "libraft-static": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
+            "libraft-tests": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": false,
@@ -3983,6 +4361,12 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "librapidsmpf-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "rapidsmpf": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
@@ -3997,6 +4381,12 @@
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "librmm-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "rmm": {
@@ -4021,10 +4411,22 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "libucxx-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "ucxx": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "ucxx-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             }
           }
@@ -4085,6 +4487,12 @@
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "libcudf-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             },
             "libcudf_kafka": {
@@ -4446,10 +4854,22 @@
               "has_wheel_package": true,
               "publishes_prereleases": true
             },
+            "libucxx-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
+              "publishes_prereleases": true
+            },
             "ucxx": {
               "has_conda_package": true,
               "has_cuda_suffix": true,
               "has_wheel_package": true,
+              "publishes_prereleases": true
+            },
+            "ucxx-tests": {
+              "has_conda_package": true,
+              "has_cuda_suffix": true,
+              "has_wheel_package": false,
               "publishes_prereleases": true
             }
           }

--- a/src/rapids_metadata/__init__.py
+++ b/src/rapids_metadata/__init__.py
@@ -313,4 +313,10 @@ all_metadata.versions["26.06"] = deepcopy(all_metadata.versions["26.04"])
 all_metadata.versions["26.08"] = deepcopy(all_metadata.versions["26.06"])
 del all_metadata.versions["26.08"].repositories["cuxfilter"]
 
+all_metadata.versions["26.08"].repositories["cudf"].packages["libcudf-streaming"] = (
+    RAPIDSPackage()
+)
+all_metadata.versions["26.08"].repositories["cudf"].packages["cudf-streaming"] = (
+    RAPIDSPackage()
+)
 all_metadata.versions["26.10"] = deepcopy(all_metadata.versions["26.08"])

--- a/src/rapids_metadata/__init__.py
+++ b/src/rapids_metadata/__init__.py
@@ -314,24 +314,19 @@ all_metadata.versions["26.08"] = deepcopy(all_metadata.versions["26.06"])
 del all_metadata.versions["26.08"].repositories["cuxfilter"]
 
 all_metadata.versions["26.08"].repositories["cudf"].packages["libcudf-streaming"] = (
-    RAPIDSPackage()
-)
-all_metadata.versions["26.08"].repositories["cudf"].packages["cudf-streaming"] = (
-    RAPIDSPackage()
-all_metadata.versions["26.08"].repositories["cudf"].packages["libcudf-streaming"] = (
     RAPIDSPackage(
-            publishes_prereleases=True,
-            has_cuda_suffix=True,
-            has_conda_package=True,
-            has_wheel_package=True,
+        publishes_prereleases=True,
+        has_cuda_suffix=True,
+        has_conda_package=True,
+        has_wheel_package=True,
     )
 )
 all_metadata.versions["26.08"].repositories["cudf"].packages["cudf-streaming"] = (
     RAPIDSPackage(
-            publishes_prereleases=True,
-            has_cuda_suffix=True,
-            has_conda_package=True,
-            has_wheel_package=True,
+        publishes_prereleases=True,
+        has_cuda_suffix=True,
+        has_conda_package=True,
+        has_wheel_package=True,
     )
 )
 all_metadata.versions["26.10"] = deepcopy(all_metadata.versions["26.08"])

--- a/src/rapids_metadata/__init__.py
+++ b/src/rapids_metadata/__init__.py
@@ -228,10 +228,82 @@ all_metadata.versions["25.02"].repositories["cuvs"].packages["libcuvs"] = RAPIDS
 all_metadata.versions["25.02"].repositories["raft"].packages["libraft"] = RAPIDSPackage(
     has_wheel_package=True
 )
+all_metadata.versions["25.02"].repositories["cudf"].packages["libcudf-tests"] = (
+    RAPIDSPackage(
+        publishes_prereleases=True,
+        has_cuda_suffix=True,
+        has_conda_package=True,
+        has_wheel_package=False,
+    )
+)
+all_metadata.versions["25.02"].repositories["cugraph"].packages["libcugraph-tests"] = (
+    RAPIDSPackage(
+        publishes_prereleases=True,
+        has_cuda_suffix=True,
+        has_conda_package=True,
+        has_wheel_package=False,
+    )
+)
+all_metadata.versions["25.02"].repositories["cuvs"].packages["libcuvs-tests"] = (
+    RAPIDSPackage(
+        publishes_prereleases=True,
+        has_cuda_suffix=True,
+        has_conda_package=True,
+        has_wheel_package=False,
+    )
+)
+all_metadata.versions["25.02"].repositories["kvikio"].packages["libkvikio-tests"] = (
+    RAPIDSPackage(
+        publishes_prereleases=True,
+        has_cuda_suffix=True,
+        has_conda_package=True,
+        has_wheel_package=False,
+    )
+)
+all_metadata.versions["25.02"].repositories["raft"].packages["libraft-tests"] = (
+    RAPIDSPackage(
+        publishes_prereleases=True,
+        has_cuda_suffix=True,
+        has_conda_package=True,
+        has_wheel_package=False,
+    )
+)
+all_metadata.versions["25.02"].repositories["rmm"].packages["librmm-tests"] = (
+    RAPIDSPackage(
+        publishes_prereleases=True,
+        has_cuda_suffix=True,
+        has_conda_package=True,
+        has_wheel_package=False,
+    )
+)
+all_metadata.versions["25.02"].repositories["cugraph-gnn"].packages[
+    "libwholegraph-tests"
+] = RAPIDSPackage(
+    publishes_prereleases=True,
+    has_cuda_suffix=True,
+    has_conda_package=True,
+    has_wheel_package=False,
+)
+all_metadata.versions["25.02"].repositories["ucxx"].packages["libucxx-tests"] = (
+    RAPIDSPackage(
+        publishes_prereleases=True,
+        has_cuda_suffix=True,
+        has_conda_package=True,
+        has_wheel_package=False,
+    )
+)
 
 all_metadata.versions["25.04"] = deepcopy(all_metadata.versions["25.02"])
 all_metadata.versions["25.04"].repositories["rapids-logger"] = RAPIDSRepository(
     packages={"rapids-logger": RAPIDSPackage(has_cuda_suffix=False)}
+)
+all_metadata.versions["25.04"].repositories["ucxx"].packages["ucxx-tests"] = (
+    RAPIDSPackage(
+        publishes_prereleases=True,
+        has_cuda_suffix=True,
+        has_conda_package=True,
+        has_wheel_package=False,
+    )
 )
 
 all_metadata.versions["25.06"] = deepcopy(all_metadata.versions["25.04"])
@@ -250,8 +322,10 @@ all_metadata.versions["25.06"].repositories["rapidsmpf"] = RAPIDSRepository(
     packages={
         "rapidsmpf": RAPIDSPackage(),
         "librapidsmpf": RAPIDSPackage(),
+        "librapidsmpf-tests": RAPIDSPackage(has_wheel_package=False),
     }
 )
+
 del all_metadata.versions["25.06"].repositories["cuspatial"]
 del all_metadata.versions["25.06"].repositories["cuml"].packages["cuml-cpu"]
 
@@ -314,96 +388,7 @@ all_metadata.versions["26.04"].repositories["nvforest"] = RAPIDSRepository(
     }
 )
 
-all_metadata.versions["26.04"].repositories["cugraph"].packages["libcugraph-tests"] = (
-    RAPIDSPackage(
-        publishes_prereleases=True,
-        has_cuda_suffix=True,
-        has_conda_package=True,
-        has_wheel_package=False,
-    )
-)
-
-all_metadata.versions["26.04"].repositories["cuvs"].packages["libcuvs-tests"] = (
-    RAPIDSPackage(
-        publishes_prereleases=True,
-        has_cuda_suffix=True,
-        has_conda_package=True,
-        has_wheel_package=False,
-    )
-)
-
-all_metadata.versions["26.04"].repositories["kvikio"].packages["libkvikio-tests"] = (
-    RAPIDSPackage(
-        publishes_prereleases=True,
-        has_cuda_suffix=True,
-        has_conda_package=True,
-        has_wheel_package=False,
-    )
-)
-
-all_metadata.versions["26.04"].repositories["raft"].packages["libraft-tests"] = (
-    RAPIDSPackage(
-        publishes_prereleases=True,
-        has_cuda_suffix=True,
-        has_conda_package=True,
-        has_wheel_package=False,
-    )
-)
-
-all_metadata.versions["26.04"].repositories["rapidsmpf"].packages[
-    "librapidsmpf-tests"
-] = RAPIDSPackage(
-    publishes_prereleases=True,
-    has_cuda_suffix=True,
-    has_conda_package=True,
-    has_wheel_package=False,
-)
-
-all_metadata.versions["26.04"].repositories["rmm"].packages["librmm-tests"] = (
-    RAPIDSPackage(
-        publishes_prereleases=True,
-        has_cuda_suffix=True,
-        has_conda_package=True,
-        has_wheel_package=False,
-    )
-)
-
-all_metadata.versions["26.04"].repositories["cugraph-gnn"].packages[
-    "libwholegraph-tests"
-] = RAPIDSPackage(
-    publishes_prereleases=True,
-    has_cuda_suffix=True,
-    has_conda_package=True,
-    has_wheel_package=False,
-)
-
 all_metadata.versions["26.06"] = deepcopy(all_metadata.versions["26.04"])
-all_metadata.versions["26.06"].repositories["cudf"].packages["libcudf-tests"] = (
-    RAPIDSPackage(
-        publishes_prereleases=True,
-        has_cuda_suffix=True,
-        has_conda_package=True,
-        has_wheel_package=False,
-    )
-)
-
-all_metadata.versions["26.06"].repositories["ucxx"].packages["libucxx-tests"] = (
-    RAPIDSPackage(
-        publishes_prereleases=True,
-        has_cuda_suffix=True,
-        has_conda_package=True,
-        has_wheel_package=False,
-    )
-)
-
-all_metadata.versions["26.06"].repositories["ucxx"].packages["ucxx-tests"] = (
-    RAPIDSPackage(
-        publishes_prereleases=True,
-        has_cuda_suffix=True,
-        has_conda_package=True,
-        has_wheel_package=False,
-    )
-)
 
 all_metadata.versions["26.08"] = deepcopy(all_metadata.versions["26.06"])
 del all_metadata.versions["26.08"].repositories["cuxfilter"]

--- a/src/rapids_metadata/__init__.py
+++ b/src/rapids_metadata/__init__.py
@@ -312,3 +312,5 @@ all_metadata.versions["26.06"] = deepcopy(all_metadata.versions["26.04"])
 
 all_metadata.versions["26.08"] = deepcopy(all_metadata.versions["26.06"])
 del all_metadata.versions["26.08"].repositories["cuxfilter"]
+
+all_metadata.versions["26.10"] = deepcopy(all_metadata.versions["26.08"])

--- a/src/rapids_metadata/__init__.py
+++ b/src/rapids_metadata/__init__.py
@@ -305,10 +305,105 @@ all_metadata.versions["26.04"].repositories["nvforest"] = RAPIDSRepository(
             has_conda_package=True,
             has_wheel_package=True,
         ),
+        "libnvforest-tests": RAPIDSPackage(
+            publishes_prereleases=True,
+            has_cuda_suffix=True,
+            has_conda_package=True,
+            has_wheel_package=False,
+        ),
     }
 )
 
+all_metadata.versions["26.04"].repositories["cugraph"].packages["libcugraph-tests"] = (
+    RAPIDSPackage(
+        publishes_prereleases=True,
+        has_cuda_suffix=True,
+        has_conda_package=True,
+        has_wheel_package=False,
+    )
+)
+
+all_metadata.versions["26.04"].repositories["cuvs"].packages["libcuvs-tests"] = (
+    RAPIDSPackage(
+        publishes_prereleases=True,
+        has_cuda_suffix=True,
+        has_conda_package=True,
+        has_wheel_package=False,
+    )
+)
+
+all_metadata.versions["26.04"].repositories["kvikio"].packages["libkvikio-tests"] = (
+    RAPIDSPackage(
+        publishes_prereleases=True,
+        has_cuda_suffix=True,
+        has_conda_package=True,
+        has_wheel_package=False,
+    )
+)
+
+all_metadata.versions["26.04"].repositories["raft"].packages["libraft-tests"] = (
+    RAPIDSPackage(
+        publishes_prereleases=True,
+        has_cuda_suffix=True,
+        has_conda_package=True,
+        has_wheel_package=False,
+    )
+)
+
+all_metadata.versions["26.04"].repositories["rapidsmpf"].packages[
+    "librapidsmpf-tests"
+] = RAPIDSPackage(
+    publishes_prereleases=True,
+    has_cuda_suffix=True,
+    has_conda_package=True,
+    has_wheel_package=False,
+)
+
+all_metadata.versions["26.04"].repositories["rmm"].packages["librmm-tests"] = (
+    RAPIDSPackage(
+        publishes_prereleases=True,
+        has_cuda_suffix=True,
+        has_conda_package=True,
+        has_wheel_package=False,
+    )
+)
+
+all_metadata.versions["26.04"].repositories["cugraph-gnn"].packages[
+    "libwholegraph-tests"
+] = RAPIDSPackage(
+    publishes_prereleases=True,
+    has_cuda_suffix=True,
+    has_conda_package=True,
+    has_wheel_package=False,
+)
+
 all_metadata.versions["26.06"] = deepcopy(all_metadata.versions["26.04"])
+all_metadata.versions["26.06"].repositories["cudf"].packages["libcudf-tests"] = (
+    RAPIDSPackage(
+        publishes_prereleases=True,
+        has_cuda_suffix=True,
+        has_conda_package=True,
+        has_wheel_package=False,
+    )
+)
+
+all_metadata.versions["26.06"].repositories["ucxx"].packages["libucxx-tests"] = (
+    RAPIDSPackage(
+        publishes_prereleases=True,
+        has_cuda_suffix=True,
+        has_conda_package=True,
+        has_wheel_package=False,
+    )
+)
+
+all_metadata.versions["26.06"].repositories["ucxx"].packages["ucxx-tests"] = (
+    RAPIDSPackage(
+        publishes_prereleases=True,
+        has_cuda_suffix=True,
+        has_conda_package=True,
+        has_wheel_package=False,
+    )
+)
 
 all_metadata.versions["26.08"] = deepcopy(all_metadata.versions["26.06"])
 del all_metadata.versions["26.08"].repositories["cuxfilter"]
@@ -321,6 +416,15 @@ all_metadata.versions["26.08"].repositories["cudf"].packages["libcudf-streaming"
         has_wheel_package=True,
     )
 )
+all_metadata.versions["26.08"].repositories["cudf"].packages[
+    "libcudf-streaming-tests"
+] = RAPIDSPackage(
+    publishes_prereleases=True,
+    has_cuda_suffix=True,
+    has_conda_package=True,
+    has_wheel_package=False,
+)
+
 all_metadata.versions["26.08"].repositories["cudf"].packages["cudf-streaming"] = (
     RAPIDSPackage(
         publishes_prereleases=True,

--- a/src/rapids_metadata/__init__.py
+++ b/src/rapids_metadata/__init__.py
@@ -318,5 +318,20 @@ all_metadata.versions["26.08"].repositories["cudf"].packages["libcudf-streaming"
 )
 all_metadata.versions["26.08"].repositories["cudf"].packages["cudf-streaming"] = (
     RAPIDSPackage()
+all_metadata.versions["26.08"].repositories["cudf"].packages["libcudf-streaming"] = (
+    RAPIDSPackage(
+            publishes_prereleases=True,
+            has_cuda_suffix=True,
+            has_conda_package=True,
+            has_wheel_package=True,
+    )
+)
+all_metadata.versions["26.08"].repositories["cudf"].packages["cudf-streaming"] = (
+    RAPIDSPackage(
+            publishes_prereleases=True,
+            has_cuda_suffix=True,
+            has_conda_package=True,
+            has_wheel_package=True,
+    )
 )
 all_metadata.versions["26.10"] = deepcopy(all_metadata.versions["26.08"])


### PR DESCRIPTION
Add entries for RAPIDS 26.10

Adds new wheel and conda packages for `cudf`
- `libcudf-streaming`
- `cudf-streaming`

Ops Issue ->  https://github.com/rapidsai/ops/issues/4667 cover's details