### PR TITLE
correct permissions for GitHub Actions workflows

### DIFF
--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -9,6 +9,12 @@ concurrency:
 permissions: {}
 jobs:
   run-checks:
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
     uses: ./.github/workflows/checks-and-builds.yaml
     with:
       build_type: branch

--- a/.github/workflows/build-tag.yaml
+++ b/.github/workflows/build-tag.yaml
@@ -9,6 +9,12 @@ concurrency:
 permissions: {}
 jobs:
   run-checks:
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
     uses: ./.github/workflows/checks-and-builds.yaml
     with:
       build_type: branch

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,6 +8,16 @@ concurrency:
   cancel-in-progress: true
 permissions: {}
 jobs:
+  # Please keep pr-builder as the top job here
+  pr-builder:
+    needs:
+      - run-checks
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@main
+    permissions:
+      contents: read
+    if: always()
+    with:
+      needs: ${{ toJSON(needs) }}
   run-checks:
     permissions:
       actions: read

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,6 +9,12 @@ concurrency:
 permissions: {}
 jobs:
   run-checks:
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
     uses: ./.github/workflows/checks-and-builds.yaml
     with:
       build_type: pull-request

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
               rapids-metadata[.]json$|
               schemas/rapids-metadata-v[0-9]+[.]json$
   - repo: https://github.com/rapidsai/dependency-file-generator
-    rev: v1.20.3
+    rev: v1.21.0
     hooks:
       - id: rapids-dependency-file-generator
         args: ["--clean", "--warn-all", "--strict"]
@@ -24,7 +24,7 @@ repos:
     hooks:
       - id: codespell
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.16
+    rev: v0.15.20
     hooks:
       - id: ruff-check
         args: ["--fix"]
@@ -35,7 +35,7 @@ repos:
       - id: shellcheck
         args: ["--severity=warning"]
   - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: v1.5.0
+    rev: v1.6.0
     hooks:
       - id: verify-copyright
         args: [--fix, --main-branch=main]
@@ -53,7 +53,7 @@ repos:
           - packaging
           - pydantic
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.25.2
+    rev: v1.26.1
     hooks:
       - id: zizmor
   - repo: local


### PR DESCRIPTION
Fixes https://github.com/rapidsai/rapids-metadata/issues/81

CI was broken by #75 ... reusable workflows need to be granted permissions at each callsite. This fixes that.

Other changes:

* updates all pre-commit hooks with `pre-commit autoupdate`
* introduces `pr-builder` workflow so branch protections can reference a single, stable job name in the list of required checks (most of RAPIDS uses this)

## Why didn't we catch this?

Because this repo doesn't have branch protections set up, so CI looked green when the workflow didn't run at all 🙃 

(I've fixed that)