### PR TITLE
enforce 'yamllint' checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,6 +52,15 @@ repos:
         additional_dependencies:
           - packaging
           - pydantic
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.38.0
+    hooks:
+      - id: yamllint
+        additional_dependencies: [pyyaml]
+        exclude: |
+          (?x)^(
+            conda/recipes/rapids-metadata/meta.yaml$
+          )
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
     rev: v1.26.1
     hooks:
@@ -74,4 +83,4 @@ repos:
           - pydantic
 
 default_language_version:
-      python: python3
+  python: python3

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+extends: default
+
+rules:
+  anchors:
+    forbid-undeclared-aliases: true
+    forbid-duplicated-anchors: true
+    forbid-unused-anchors: true
+  braces:
+    forbid: false
+    min-spaces-inside: 0
+    # allow 1 space for jinja templating in conda recipes
+    max-spaces-inside: 1
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  brackets: enable
+  colons:
+    max-spaces-before: 0
+    max-spaces-after: 1
+  commas:
+    max-spaces-before: 0
+    min-spaces-after: 1
+    max-spaces-after: 1
+  comments: disable
+  comments-indentation: disable
+  document-end: disable
+  document-start: disable
+  key-duplicates:
+    forbid-duplicated-merge-keys: true
+  line-length: disable
+  truthy:
+    allowed-values: ['false', 'true']
+    # having problematic value in keys is rare... and also
+    # GitHub Actions' choie of 'on:' triggers this check
+    # ref: https://github.com/adrienverge/yamllint/issues/430
+    check-keys: false


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/305

Proposes enforcing `yamllint` checks here. My primary motivation is to catch correctness issues in `dependencies.yaml` files, like duplicate entries silently resolving to the last one or indentation mistakes leading to filters being ignored.

But this also has some side benefits for consistency, which makes it a bit easier to write automation.
