### PR TITLE
Mark cudf_kafka and libcudf_kafka as `has_cuda_suffix=False`

### DIFF
--- a/rapids-metadata.json
+++ b/rapids-metadata.json
@@ -44,7 +44,7 @@
             },
             "cudf_kafka": {
               "has_conda_package": true,
-              "has_cuda_suffix": true,
+              "has_cuda_suffix": false,
               "has_wheel_package": false,
               "publishes_prereleases": true
             },
@@ -68,7 +68,7 @@
             },
             "libcudf_kafka": {
               "has_conda_package": true,
-              "has_cuda_suffix": true,
+              "has_cuda_suffix": false,
               "has_wheel_package": false,
               "publishes_prereleases": true
             }
@@ -448,7 +448,7 @@
             },
             "cudf_kafka": {
               "has_conda_package": true,
-              "has_cuda_suffix": true,
+              "has_cuda_suffix": false,
               "has_wheel_package": false,
               "publishes_prereleases": true
             },
@@ -472,7 +472,7 @@
             },
             "libcudf_kafka": {
               "has_conda_package": true,
-              "has_cuda_suffix": true,
+              "has_cuda_suffix": false,
               "has_wheel_package": false,
               "publishes_prereleases": true
             },
@@ -874,7 +874,7 @@
             },
             "cudf_kafka": {
               "has_conda_package": true,
-              "has_cuda_suffix": true,
+              "has_cuda_suffix": false,
               "has_wheel_package": false,
               "publishes_prereleases": true
             },
@@ -898,7 +898,7 @@
             },
             "libcudf_kafka": {
               "has_conda_package": true,
-              "has_cuda_suffix": true,
+              "has_cuda_suffix": false,
               "has_wheel_package": false,
               "publishes_prereleases": true
             },
@@ -1304,7 +1304,7 @@
             },
             "cudf_kafka": {
               "has_conda_package": true,
-              "has_cuda_suffix": true,
+              "has_cuda_suffix": false,
               "has_wheel_package": false,
               "publishes_prereleases": true
             },
@@ -1334,7 +1334,7 @@
             },
             "libcudf_kafka": {
               "has_conda_package": true,
-              "has_cuda_suffix": true,
+              "has_cuda_suffix": false,
               "has_wheel_package": false,
               "publishes_prereleases": true
             },
@@ -1769,7 +1769,7 @@
             },
             "cudf_kafka": {
               "has_conda_package": true,
-              "has_cuda_suffix": true,
+              "has_cuda_suffix": false,
               "has_wheel_package": false,
               "publishes_prereleases": true
             },
@@ -1799,7 +1799,7 @@
             },
             "libcudf_kafka": {
               "has_conda_package": true,
-              "has_cuda_suffix": true,
+              "has_cuda_suffix": false,
               "has_wheel_package": false,
               "publishes_prereleases": true
             },
@@ -2250,7 +2250,7 @@
             },
             "cudf_kafka": {
               "has_conda_package": true,
-              "has_cuda_suffix": true,
+              "has_cuda_suffix": false,
               "has_wheel_package": false,
               "publishes_prereleases": true
             },
@@ -2280,7 +2280,7 @@
             },
             "libcudf_kafka": {
               "has_conda_package": true,
-              "has_cuda_suffix": true,
+              "has_cuda_suffix": false,
               "has_wheel_package": false,
               "publishes_prereleases": true
             },
@@ -2719,7 +2719,7 @@
             },
             "cudf_kafka": {
               "has_conda_package": true,
-              "has_cuda_suffix": true,
+              "has_cuda_suffix": false,
               "has_wheel_package": false,
               "publishes_prereleases": true
             },
@@ -2749,7 +2749,7 @@
             },
             "libcudf_kafka": {
               "has_conda_package": true,
-              "has_cuda_suffix": true,
+              "has_cuda_suffix": false,
               "has_wheel_package": false,
               "publishes_prereleases": true
             },
@@ -3172,7 +3172,7 @@
             },
             "cudf_kafka": {
               "has_conda_package": true,
-              "has_cuda_suffix": true,
+              "has_cuda_suffix": false,
               "has_wheel_package": false,
               "publishes_prereleases": true
             },
@@ -3202,7 +3202,7 @@
             },
             "libcudf_kafka": {
               "has_conda_package": true,
-              "has_cuda_suffix": true,
+              "has_cuda_suffix": false,
               "has_wheel_package": false,
               "publishes_prereleases": true
             },
@@ -3615,7 +3615,7 @@
             },
             "cudf_kafka": {
               "has_conda_package": true,
-              "has_cuda_suffix": true,
+              "has_cuda_suffix": false,
               "has_wheel_package": false,
               "publishes_prereleases": true
             },
@@ -3645,7 +3645,7 @@
             },
             "libcudf_kafka": {
               "has_conda_package": true,
-              "has_cuda_suffix": true,
+              "has_cuda_suffix": false,
               "has_wheel_package": false,
               "publishes_prereleases": true
             },
@@ -4046,7 +4046,7 @@
             },
             "cudf_kafka": {
               "has_conda_package": true,
-              "has_cuda_suffix": true,
+              "has_cuda_suffix": false,
               "has_wheel_package": false,
               "publishes_prereleases": true
             },
@@ -4076,7 +4076,7 @@
             },
             "libcudf_kafka": {
               "has_conda_package": true,
-              "has_cuda_suffix": true,
+              "has_cuda_suffix": false,
               "has_wheel_package": false,
               "publishes_prereleases": true
             },
@@ -4467,7 +4467,7 @@
             },
             "cudf_kafka": {
               "has_conda_package": true,
-              "has_cuda_suffix": true,
+              "has_cuda_suffix": false,
               "has_wheel_package": false,
               "publishes_prereleases": true
             },
@@ -4497,7 +4497,7 @@
             },
             "libcudf_kafka": {
               "has_conda_package": true,
-              "has_cuda_suffix": true,
+              "has_cuda_suffix": false,
               "has_wheel_package": false,
               "publishes_prereleases": true
             },
@@ -4910,7 +4910,7 @@
             },
             "cudf_kafka": {
               "has_conda_package": true,
-              "has_cuda_suffix": true,
+              "has_cuda_suffix": false,
               "has_wheel_package": false,
               "publishes_prereleases": true
             },
@@ -4940,7 +4940,7 @@
             },
             "libcudf_kafka": {
               "has_conda_package": true,
-              "has_cuda_suffix": true,
+              "has_cuda_suffix": false,
               "has_wheel_package": false,
               "publishes_prereleases": true
             },
@@ -5359,7 +5359,7 @@
             },
             "cudf_kafka": {
               "has_conda_package": true,
-              "has_cuda_suffix": true,
+              "has_cuda_suffix": false,
               "has_wheel_package": false,
               "publishes_prereleases": true
             },
@@ -5401,7 +5401,7 @@
             },
             "libcudf_kafka": {
               "has_conda_package": true,
-              "has_cuda_suffix": true,
+              "has_cuda_suffix": false,
               "has_wheel_package": false,
               "publishes_prereleases": true
             },
@@ -5810,7 +5810,7 @@
             },
             "cudf_kafka": {
               "has_conda_package": true,
-              "has_cuda_suffix": true,
+              "has_cuda_suffix": false,
               "has_wheel_package": false,
               "publishes_prereleases": true
             },
@@ -5852,7 +5852,7 @@
             },
             "libcudf_kafka": {
               "has_conda_package": true,
-              "has_cuda_suffix": true,
+              "has_cuda_suffix": false,
               "has_wheel_package": false,
               "publishes_prereleases": true
             },

--- a/src/rapids_metadata/__init__.py
+++ b/src/rapids_metadata/__init__.py
@@ -43,11 +43,15 @@ all_metadata.versions["24.08"] = RAPIDSVersion(
             packages={
                 "cudf": RAPIDSPackage(),
                 "cudf-polars": RAPIDSPackage(),
-                "cudf_kafka": RAPIDSPackage(has_wheel_package=False),
+                "cudf_kafka": RAPIDSPackage(
+                    has_wheel_package=False, has_cuda_suffix=False
+                ),
                 "custreamz": RAPIDSPackage(has_wheel_package=False),
                 "dask-cudf": RAPIDSPackage(),
                 "libcudf": RAPIDSPackage(),
-                "libcudf_kafka": RAPIDSPackage(has_wheel_package=False),
+                "libcudf_kafka": RAPIDSPackage(
+                    has_wheel_package=False, has_cuda_suffix=False
+                ),
             }
         ),
         "cugraph": RAPIDSRepository(


### PR DESCRIPTION
These packages have never produced wheels, so it does not make sense for them to be marked as `has_cuda_suffix=True`.