### PR TITLE
Mark rapids-logger as not publishing prereleases

### DIFF
--- a/rapids-metadata.json
+++ b/rapids-metadata.json
@@ -6137,7 +6137,7 @@
               "has_conda_package": true,
               "has_cuda_suffix": false,
               "has_wheel_package": true,
-              "publishes_prereleases": true
+              "publishes_prereleases": false
             }
           }
         },

--- a/src/rapids_metadata/__init__.py
+++ b/src/rapids_metadata/__init__.py
@@ -423,3 +423,6 @@ all_metadata.versions["26.08"].repositories["cudf"].packages["cudf-streaming"] =
     )
 )
 all_metadata.versions["26.10"] = deepcopy(all_metadata.versions["26.08"])
+all_metadata.versions["26.10"].repositories["rapids-logger"].packages[
+    "rapids-logger"
+].publishes_prereleases = False


### PR DESCRIPTION
Marks `rapids-logger` as not publishing prereleases for RAPIDS 26.10 so dependency validation no longer requires `>=0.0.0a0`.

Contributes to https://github.com/rapidsai/build-planning/issues/313.